### PR TITLE
Require message-factory version that has Puli bindings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "psr/http-message": "^1.0",
-        "php-http/message-factory": "^1.0",
+        "php-http/message-factory": "^1.0.2",
         "clue/stream-filter": "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
message-factory 1.0.0 didn't yet have Puli bindings, which causes trouble
when installing php-http packages using Composer's --prefer-lowest.