### PR TITLE
Lower buffer size, and use it in the getContents

### DIFF
--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\StreamInterface;
  */
 abstract class FilteredStream implements StreamInterface
 {
-    const BUFFER_SIZE = 65536;
+    const BUFFER_SIZE = 8192;
 
     use StreamDecorator;
 
@@ -115,7 +115,7 @@ abstract class FilteredStream implements StreamInterface
         $buffer = '';
 
         while (!$this->eof()) {
-            $buf = $this->read(1048576);
+            $buf = $this->read(self::BUFFER_SIZE);
             // Using a loose equality here to match on '' and false.
             if ($buf == null) {
                 break;


### PR DESCRIPTION
This is mainly to avoid too much nested call to the read method, as if we got a stream where the reads provide too few bytes (like 100) it will make a nested call to the read method for each part of the messages and will stop on a too muche nested call exception with xdebug.

Also there is no need to have more than 8192 as PHP already have a buffer with this size, so no performance issue.