### PR TITLE
adjust request matcher to the symfony model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- The RequestMatcher is built after the Symfony RequestMatcher and separates
+   scheme, host and path expressions and provides an option to filter on the
+   method. The RegexRequestMatcher is deprecated and will be removed in 2.0.
 - New RequestConditional authentication method using request matchers (deprecates Matching auth method)
 
 

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
     }
 }

--- a/spec/RequestMatcher/RequestMatcherSpec.php
+++ b/spec/RequestMatcher/RequestMatcherSpec.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace spec\Http\Message\RequestMatcher;
+
+use Http\Message\RequestMatcher;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use PhpSpec\ObjectBehavior;
+
+class RequestMatcherSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Message\RequestMatcher\RequestMatcher');
+    }
+
+    function it_is_a_request_matcher()
+    {
+        $this->shouldImplement('Http\Message\RequestMatcher');
+    }
+
+    function it_matches_a_path(RequestInterface $request, UriInterface $uri)
+    {
+        $this->beConstructedWith('^/tes?');
+
+        $request->getUri()->willReturn($uri);
+        $uri->getPath()->willReturn('/test/foo');
+
+        $this->matches($request)->shouldReturn(true);
+    }
+
+    function it_does_not_match_a_path(RequestInterface $request, UriInterface $uri)
+    {
+        $this->beConstructedWith('#^/tes?#');
+
+        $request->getUri()->willReturn($uri);
+        $uri->getPath()->willReturn('/ttttt');
+
+        $this->matches($request)->shouldReturn(false);
+    }
+
+
+    function it_matches_a_host(RequestInterface $request, UriInterface $uri)
+    {
+        $this->beConstructedWith(null, 'php-htt?');
+
+        $request->getUri()->willReturn($uri);
+        $uri->getHost()->willReturn('php-http.org');
+
+        $this->matches($request)->shouldReturn(true);
+    }
+
+    function it_does_not_match_a_host(RequestInterface $request, UriInterface $uri)
+    {
+        $this->beConstructedWith(null, 'php-htt?');
+
+        $request->getUri()->willReturn($uri);
+        $uri->getHost()->willReturn('httplug.io');
+
+        $this->matches($request)->shouldReturn(false);
+    }
+
+    function it_matches_a_method(RequestInterface $request)
+    {
+        $this->beConstructedWith(null, null, 'get');
+
+        $request->getMethod()->willReturn('GET');
+
+        $this->matches($request)->shouldReturn(true);
+    }
+
+    function it_does_not_match_a_method(RequestInterface $request)
+    {
+        $this->beConstructedWith(null, null, 'get');
+
+        $request->getMethod()->willReturn('post');
+
+        $this->matches($request)->shouldReturn(false);
+    }
+
+
+    function it_matches_a_scheme(RequestInterface $request, UriInterface $uri)
+    {
+        $this->beConstructedWith(null, null, null, 'http');
+
+        $request->getUri()->willReturn($uri);
+        $uri->getScheme()->willReturn('http');
+
+        $this->matches($request)->shouldReturn(true);
+    }
+
+    function it_does_not_match_a_scheme(RequestInterface $request, UriInterface $uri)
+    {
+        $this->beConstructedWith(null, null, null, 'http');
+
+        $request->getUri()->willReturn($uri);
+        $uri->getScheme()->willReturn('https');
+
+        $this->matches($request)->shouldReturn(false);
+    }
+}

--- a/src/Authentication/Matching.php
+++ b/src/Authentication/Matching.php
@@ -6,12 +6,14 @@ use Http\Message\Authentication;
 use Http\Message\RequestMatcher\CallbackRequestMatcher;
 use Psr\Http\Message\RequestInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\Matching class is deprecated since version 1.2 and will be removed in 2.0. Use Http\Message\Authentication\RequestConditional instead.', E_USER_DEPRECATED);
+
 /**
  * Authenticate a PSR-7 Request if the request is matching.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  *
- * @deprecated since since version 1.1, to be removed in 2.0. Use {@link RequestConditional} instead.
+ * @deprecated since since version 1.2, and will be removed in 2.0. Use {@link RequestConditional} instead.
  */
 final class Matching implements Authentication
 {

--- a/src/RequestMatcher/RegexRequestMatcher.php
+++ b/src/RequestMatcher/RegexRequestMatcher.php
@@ -5,10 +5,14 @@ namespace Http\Message\RequestMatcher;
 use Http\Message\RequestMatcher;
 use Psr\Http\Message\RequestInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\RegexRequestMatcher class is deprecated since version 1.2 and will be removed in 2.0. Use Http\Message\RequestMatcher\RequestMatcher instead.', E_USER_DEPRECATED);
+
 /**
  * Match a request with a regex on the uri.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
+ *
+ * @deprecated since version 1.2 and will be removed in 2.0. Use {@link RequestMatcher} instead.
  */
 final class RegexRequestMatcher implements RequestMatcher
 {
@@ -19,6 +23,9 @@ final class RegexRequestMatcher implements RequestMatcher
      */
     private $regex;
 
+    /**
+     * @param string $regex
+     */
     public function __construct($regex)
     {
         $this->regex = $regex;

--- a/src/RequestMatcher/RequestMatcher.php
+++ b/src/RequestMatcher/RequestMatcher.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Http\Message\RequestMatcher;
+
+use Http\Message\RequestMatcher as RequestMatcherInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * A port of the Symfony RequestMatcher for PSR-7.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+final class RequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var array
+     */
+    private $methods = [];
+
+    /**
+     * @var string[]
+     */
+    private $schemes = [];
+
+    /**
+     * The regular expressions used for path or host must be specified without delimiter.
+     * You do not need to escape the forward slash / to match it.
+     *
+     * @param string|null          $path    Regular expression for the path
+     * @param string|null          $host    Regular expression for the hostname
+     * @param string|string[]|null $methods Method or list of methods to match
+     * @param string|string[]|null $schemes Scheme or list of schemes to match (e.g. http or https)
+     */
+    public function __construct($path = null, $host = null, $methods = [], $schemes = [])
+    {
+        $this->path = $path;
+        $this->host = $host;
+        $this->methods = array_map('strtoupper', (array) $methods);
+        $this->schemes = array_map('strtolower', (array) $schemes);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function matches(RequestInterface $request)
+    {
+        if ($this->schemes && !in_array($request->getUri()->getScheme(), $this->schemes)) {
+            return false;
+        }
+
+        if ($this->methods && !in_array($request->getMethod(), $this->methods)) {
+            return false;
+        }
+
+        if (null !== $this->path && !preg_match('{'.$this->path.'}', rawurldecode($request->getUri()->getPath()))) {
+            return false;
+        }
+
+        if (null !== $this->host && !preg_match('{'.$this->host.'}i', $request->getUri()->getHost())) {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
fix #33

this matcher has less options than the Symfony request matcher. a Symfony request is more like the ServerRequestInterface of psr 7 and we mainly work with client requests, so matching on the client ip makes no sense. and psr 7 requests have no attributes so i dropped that as well.