### PR TITLE
Added a formatter that shows the full header and body of the HTTP message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-### Fixed
- 
-- #41: Response builder broke header value
-
 ### Added
 
 - The FullHttpMessageFormatter was added
+
+### Fixed
+ 
+- #41: Response builder broke header value
 
 ## 1.2.0 - 2016-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
  
 - #41: Response builder broke header value
 
+### Added
+
+- The FullHttpMessageFormatter was added
 
 ## 1.2.0 - 2016-03-29
 

--- a/src/Formatter/FullHttpMessageFormatter.php
+++ b/src/Formatter/FullHttpMessageFormatter.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Http\Message\Formatter;
+
+use Http\Message\Formatter;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A formatter that prints the complete HTTP message.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class FullHttpMessageFormatter implements Formatter
+{
+    /**
+     * The maximum length of the body.
+     *
+     * @var int
+     */
+    private $maxBodyLendth;
+
+    /**
+     * @param int $maxBodyLendth number of chars.
+     */
+    public function __construct($maxBodyLendth = 1000)
+    {
+        $this->maxBodyLendth = $maxBodyLendth;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function formatRequest(RequestInterface $request)
+    {
+        $message = sprintf(
+            "%s %s HTTP/%s\n",
+            $request->getMethod(),
+            $request->getRequestTarget(),
+            $request->getProtocolVersion()
+        );
+
+        foreach ($request->getHeaders() as $name => $values) {
+            $message .= $name.': '.implode(', ', $values)."\n";
+        }
+
+        $message .= "\n".mb_substr($request->getBody()->__toString(), 0, $this->maxBodyLendth);
+
+        return $message;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function formatResponse(ResponseInterface $response)
+    {
+        $message = sprintf(
+            "HTTP/%s %s %s\n",
+            $response->getProtocolVersion(),
+            $response->getStatusCode(),
+            $response->getReasonPhrase()
+        );
+
+        foreach ($response->getHeaders() as $name => $values) {
+            $message .= $name.': '.implode(', ', $values)."\n";
+        }
+
+        $message .= "\n".mb_substr($response->getBody()->__toString(), 0, $this->maxBodyLendth);
+
+        return $message;
+    }
+}

--- a/src/Formatter/FullHttpMessageFormatter.php
+++ b/src/Formatter/FullHttpMessageFormatter.php
@@ -18,14 +18,14 @@ class FullHttpMessageFormatter implements Formatter
      *
      * @var int
      */
-    private $maxBodyLendth;
+    private $maxBodyLength;
 
     /**
-     * @param int $maxBodyLendth number of chars.
+     * @param int $maxBodyLength
      */
-    public function __construct($maxBodyLendth = 1000)
+    public function __construct($maxBodyLength = 1000)
     {
-        $this->maxBodyLendth = $maxBodyLendth;
+        $this->maxBodyLength = $maxBodyLength;
     }
 
     /**
@@ -44,7 +44,7 @@ class FullHttpMessageFormatter implements Formatter
             $message .= $name.': '.implode(', ', $values)."\n";
         }
 
-        $message .= "\n".mb_substr($request->getBody()->__toString(), 0, $this->maxBodyLendth);
+        $message .= "\n".mb_substr($request->getBody()->__toString(), 0, $this->maxBodyLength);
 
         return $message;
     }
@@ -65,7 +65,7 @@ class FullHttpMessageFormatter implements Formatter
             $message .= $name.': '.implode(', ', $values)."\n";
         }
 
-        $message .= "\n".mb_substr($response->getBody()->__toString(), 0, $this->maxBodyLendth);
+        $message .= "\n".mb_substr($response->getBody()->__toString(), 0, $this->maxBodyLength);
 
         return $message;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | no
| License         | MIT


#### What's in this PR?

A new formatter that show the full HTTP message. The formatter takes a constructor argument to adjust the length of the body. If the length is set to `0` we would only see the headers. (naturally). 


#### Why?

I will need this formatter in a (WIP) PR on the HTTPlug bundle. I want to show the changes each Plugin does on the request and responses. 

Im not sure this formatter belongs here, but I think there is a fairly common use case to be able to see full requests. If it is rejected here I will push it to the HTTPlug repo. 

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix