### PR TITLE
Add Message cloner

### DIFF
--- a/spec/MessageClonerSpec.php
+++ b/spec/MessageClonerSpec.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace spec\Http\Message;
+
+use Http\Message\MemoryClonedStream;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\MessageInterface;
+use spec\Http\Message\Encoding\MemoryStream;
+
+class MessageClonerSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Message\MessageCloner');
+    }
+
+    public function it_clone_a_message(MessageInterface $message, MessageInterface $messageCloned)
+    {
+        $stream = new MemoryStream('test');
+        $message->getBody()->willReturn($stream);
+        $message->withBody(Argument::type(MemoryClonedStream::class))->willReturn($messageCloned);
+
+        $this->cloneMessage($message)->shouldEqual($messageCloned);
+    }
+}

--- a/spec/MessageClonerSpec.php
+++ b/spec/MessageClonerSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\Http\Message;
 
-use Http\Message\MemoryClonedStream;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\MessageInterface;
@@ -19,7 +18,7 @@ class MessageClonerSpec extends ObjectBehavior
     {
         $stream = new MemoryStream('test');
         $message->getBody()->willReturn($stream);
-        $message->withBody(Argument::type(MemoryClonedStream::class))->willReturn($messageCloned);
+        $message->withBody(Argument::type('Http\Message\MemoryClonedStream'))->willReturn($messageCloned);
 
         $this->cloneMessage($message)->shouldEqual($messageCloned);
     }

--- a/src/MemoryClonedStream.php
+++ b/src/MemoryClonedStream.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Http\Message;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Represent a stream cloned into memory.
+ */
+class MemoryClonedStream implements StreamInterface
+{
+    const COPY_BUFFER = 8192;
+
+    private $resource;
+
+    private $size;
+
+    /**
+     * @param StreamInterface $stream        Stream to clone
+     * @param bool            $useFileBuffer Use a file buffer to avoid memory consumption on PHP script (default to true)
+     * @param int             $memoryBuffer  The amount of memory of which the stream is buffer into a file when setting
+     *                                       $useFileBuffer to true (default to 2MB)
+     */
+    public function __construct(StreamInterface $stream, $useFileBuffer = true, $memoryBuffer = 2097152)
+    {
+        $this->size = 0;
+
+        if ($useFileBuffer) {
+            $this->resource = fopen('php://temp/maxmemory:'.$memoryBuffer, 'rw+');
+        } else {
+            $this->resource = fopen('php://memory', 'rw+');
+        }
+
+        $position = null;
+
+        if ($stream->isSeekable()) {
+            $position = $stream->tell();
+            $stream->rewind();
+        }
+
+        while (!$stream->eof()) {
+            $this->size += fwrite($this->resource, $stream->read(self::COPY_BUFFER));
+        }
+
+        if ($stream->isSeekable()) {
+            $stream->seek($position);
+        }
+
+        rewind($this->resource);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->getContents();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        fclose($this->resource);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function detach()
+    {
+        $resource = $this->resource;
+        $this->resource = null;
+
+        return $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tell()
+    {
+        return ftell($this->resource);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eof()
+    {
+        return feof($this->resource);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSeekable()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        return fseek($this->resource, $offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        return rewind($this->resource);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($string)
+    {
+        return fwrite($this->resource, $string);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($length)
+    {
+        return fread($this->resource, $length);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContents()
+    {
+        $this->rewind();
+
+        return $this->read($this->size);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($key = null)
+    {
+        $metadata = stream_get_meta_data($this->resource);
+
+        if (null === $key) {
+            return $metadata;
+        }
+
+        return $metadata[$key];
+    }
+}

--- a/src/MessageCloner.php
+++ b/src/MessageCloner.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Http\Message;
+
+use Psr\Http\Message\MessageInterface;
+
+/**
+ * Allow to clone request and response.
+ *
+ * A message cloner is only necessary when you also want to duplicate the stream of a request or a response, as by
+ * default object returned by `clone $message` call will have the same stream as the cloned one, so reading the body of
+ * one of the message will affect the other.
+ */
+class MessageCloner
+{
+    /**
+     * Clone a message.
+     *
+     * When cloning you have to be careful that the original stream is rewindable. If not the original stream will be
+     * readed and cannot be readed one more time. To avoid this behavior, when the original stream is not seekable, you
+     * can clone the cloned message, and replace the original message with one of the clone, as there are always rewindable.
+     *
+     * @param MessageInterface $message
+     *
+     * @return MessageInterface|static
+     */
+    public function cloneMessage(MessageInterface $message)
+    {
+        return $message->withBody(new MemoryClonedStream($message->getBody()));
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #46
| Documentation   | Does the phpdoc is enough ?
| License         | MIT

#### What's in this PR?

Add a class to copy a request including it's body

#### Why?

IMO cloning a request with its stream his something that is shared by some concepts (like logging, caching, ....)

#### Example Usage

```php
$cloner = new MessageCloner();

$clonedResponse = $cloner->cloneMessage($response);

// If original stream is not seekable, cloned it a second time to ensure that we can read it
if (!$response->getBody()->isSeekable()) {
    $response = $cloner->cloneMessage($clonedResponse);
}
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe new feature
- [ ] Documentation pull request created
- [ ] Add a plugin "EnsureSeekable" : Goal is to have a plugin that ensure that the body of a request or response is always seekable.
