### PR TITLE
Add message, stream and URI factories for Slim Framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ before_install:
 install:
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
 
+before_script:
+    - if [[ "${TRAVIS_PHP_VERSION}" == "5.4" ]]; then composer remove slim/slim; fi
+
 script:
     - $TEST_COMMAND
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,11 @@ matrix:
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if [[ "${TRAVIS_PHP_VERSION}" == "5.4" ]]; then composer remove slim/slim --dev --no-update; fi
     - travis_retry composer self-update
 
 install:
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
-
-before_script:
-    - if [[ "${TRAVIS_PHP_VERSION}" == "5.4" ]]; then composer remove slim/slim; fi
 
 script:
     - $TEST_COMMAND

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Message, stream and URI factories for [Slim Framework](https://github.com/slimphp/Slim)
 
 ## 1.3.1 - 2016-07-15
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "suggest": {
         "zendframework/zend-diactoros": "Used with Diactoros Factories",
         "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
-        "slim/slim": "Used with Slim Factories",
+        "slim/slim": "Used with Slim Framework PSR-7 implementation",
         "ext-zlib": "Used with compressor/decompressor streams"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.4",
         "psr/http-message": "^1.0",
         "php-http/message-factory": "^1.0.2",
-        "clue/stream-filter": "^1.3"
+        "clue/stream-filter": "^1.3",
+        "slim/slim": "^3.5"
     },
     "require-dev": {
         "zendframework/zend-diactoros": "^1.0",
@@ -23,7 +24,7 @@
         "phpspec/phpspec": "^2.4",
         "henrikbjorn/phpspec-code-coverage" : "^1.0",
         "coduo/phpspec-data-provider-extension": "^1.0",
-        "slim/slim": "^3.5"
+        "akeneo/phpspec-skip-example-extension": "^1.0"
     },
     "suggest": {
         "zendframework/zend-diactoros": "Used with Diactoros Factories",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "php": ">=5.4",
         "psr/http-message": "^1.0",
         "php-http/message-factory": "^1.0.2",
-        "clue/stream-filter": "^1.3",
-        "slim/slim": "^3.5"
+        "clue/stream-filter": "^1.3"
     },
     "require-dev": {
         "zendframework/zend-diactoros": "^1.0",
@@ -24,7 +23,8 @@
         "phpspec/phpspec": "^2.4",
         "henrikbjorn/phpspec-code-coverage" : "^1.0",
         "coduo/phpspec-data-provider-extension": "^1.0",
-        "akeneo/phpspec-skip-example-extension": "^1.0"
+        "akeneo/phpspec-skip-example-extension": "^1.0",
+        "slim/slim": "^3.5"
     },
     "suggest": {
         "zendframework/zend-diactoros": "Used with Diactoros Factories",

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,13 @@
         "ext-zlib": "*",
         "phpspec/phpspec": "^2.4",
         "henrikbjorn/phpspec-code-coverage" : "^1.0",
-        "coduo/phpspec-data-provider-extension": "^1.0"
+        "coduo/phpspec-data-provider-extension": "^1.0",
+        "slim/slim": "^3.5"
     },
     "suggest": {
         "zendframework/zend-diactoros": "Used with Diactoros Factories",
         "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
+        "slim/slim": "Used with Slim Factories",
         "ext-zlib": "Used with compressor/decompressor streams"
     },
     "autoload": {

--- a/phpspec.ci.yml
+++ b/phpspec.ci.yml
@@ -6,6 +6,7 @@ formatter.name: pretty
 extensions:
     - PhpSpec\Extension\CodeCoverageExtension
     - Coduo\PhpSpec\DataProvider\DataProviderExtension
+    - Akeneo\SkipExampleExtension
 code_coverage:
     format: clover
     output: build/coverage.xml

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -5,3 +5,4 @@ suites:
 formatter.name: pretty
 extensions:
     - Coduo\PhpSpec\DataProvider\DataProviderExtension
+    - Akeneo\SkipExampleExtension

--- a/spec/MessageFactory/SlimMessageFactorySpec.php
+++ b/spec/MessageFactory/SlimMessageFactorySpec.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace spec\Http\Message\MessageFactory;
+
+use PhpSpec\ObjectBehavior;
+
+class SlimMessageFactorySpec extends ObjectBehavior
+{
+    use MessageFactoryBehavior;
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Message\MessageFactory\SlimMessageFactory');
+    }
+}

--- a/spec/MessageFactory/SlimMessageFactorySpec.php
+++ b/spec/MessageFactory/SlimMessageFactorySpec.php
@@ -4,6 +4,9 @@ namespace spec\Http\Message\MessageFactory;
 
 use PhpSpec\ObjectBehavior;
 
+/**
+ * @require Slim\Http\Request
+ */
 class SlimMessageFactorySpec extends ObjectBehavior
 {
     use MessageFactoryBehavior;

--- a/spec/StreamFactory/SlimStreamFactorySpec.php
+++ b/spec/StreamFactory/SlimStreamFactorySpec.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace spec\Http\Message\StreamFactory;
+
+use Slim\Http\Stream;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @require Slim\Http\Stream
+ */
+class SlimStreamFactorySpec extends ObjectBehavior
+{
+    use StreamFactoryBehavior;
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Message\StreamFactory\SlimStreamFactory');
+    }
+
+    function it_creates_a_stream_from_stream()
+    {
+        $resource = fopen('php://memory', 'rw');
+        $this->createStream(new Stream($resource))
+            ->shouldHaveType('Psr\Http\Message\StreamInterface');
+    }
+}

--- a/spec/UriFactory/SlimUriFactorySpec.php
+++ b/spec/UriFactory/SlimUriFactorySpec.php
@@ -5,6 +5,9 @@ namespace spec\Http\Message\UriFactory;
 use Psr\Http\Message\UriInterface;
 use PhpSpec\ObjectBehavior;
 
+/**
+ * @require Slim\Http\Uri
+ */
 class SlimUriFactorySpec extends ObjectBehavior
 {
     use UriFactoryBehavior;

--- a/spec/UriFactory/SlimUriFactorySpec.php
+++ b/spec/UriFactory/SlimUriFactorySpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\Http\Message\UriFactory;
+
+use Psr\Http\Message\UriInterface;
+use PhpSpec\ObjectBehavior;
+
+class SlimUriFactorySpec extends ObjectBehavior
+{
+    use UriFactoryBehavior;
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Message\UriFactory\SlimUriFactory');
+    }
+
+    /**
+     * TODO: Remove this when https://github.com/phpspec/phpspec/issues/825 is resolved
+     */
+    function it_creates_a_uri_from_uri(UriInterface $uri)
+    {
+        $this->createUri($uri)->shouldReturn($uri);
+    }
+}

--- a/src/MessageFactory/SlimMessageFactory.php
+++ b/src/MessageFactory/SlimMessageFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Http\Message\MessageFactory;
+
+use Http\Message\StreamFactory\SlimStreamFactory;
+use Http\Message\UriFactory\SlimUriFactory;
+use Http\Message\MessageFactory;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Http\Headers;
+
+/**
+ * Creates Slim 3 messages.
+ *
+ * @author Mika Tuupola <tuupola@appelsiini.net>
+ */
+final class SlimMessageFactory implements MessageFactory
+{
+    /**
+     * @var SlimStreamFactory
+     */
+    private $streamFactory;
+
+    /**
+     * @var SlimUriFactory
+     */
+    private $uriFactory;
+
+    public function __construct()
+    {
+        $this->streamFactory = new SlimStreamFactory();
+        $this->uriFactory = new SlimUriFactory();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createRequest(
+        $method,
+        $uri,
+        array $headers = [],
+        $body = null,
+        $protocolVersion = '1.1'
+    ) {
+        return (new Request(
+            $method,
+            $this->uriFactory->createUri($uri),
+            new Headers($headers),
+            [],
+            [],
+            $this->streamFactory->createStream($body),
+            []
+        ))->withProtocolVersion($protocolVersion);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createResponse(
+        $statusCode = 200,
+        $reasonPhrase = null,
+        array $headers = [],
+        $body = null,
+        $protocolVersion = '1.1'
+    ) {
+        return (new Response(
+            $statusCode,
+            new Headers($headers),
+            $this->streamFactory->createStream($body)
+        ))->withProtocolVersion($protocolVersion);
+    }
+}

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Http\Message\StreamFactory;
+
+use Http\Message\StreamFactory;
+use Psr\Http\Message\StreamInterface;
+use Slim\Http\Stream;
+
+/**
+ * Creates Slim 3 streams.
+ *
+ * @author Mika Tuupola <tuupola@appelsiini.net>
+ */
+final class SlimStreamFactory implements StreamFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createStream($body = null)
+    {
+        if ($body instanceof StreamInterface) {
+            return $body;
+        }
+
+        if (is_resource($body)) {
+            $stream = new Stream($body);
+        } else {
+            $resource = fopen('php://memory', 'rw');
+            $stream = new Stream($resource);
+
+            if (null !== $body) {
+                $stream->write((string) $body);
+            }
+        }
+
+        $stream->rewind();
+
+        return $stream;
+    }
+}

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -25,7 +25,7 @@ final class SlimStreamFactory implements StreamFactory
         if (is_resource($body)) {
             $stream = new Stream($body);
         } else {
-            $resource = fopen('php://memory', 'rw');
+            $resource = fopen('php://memory', 'r+');
             $stream = new Stream($resource);
 
             if (null !== $body) {

--- a/src/UriFactory/SlimUriFactory.php
+++ b/src/UriFactory/SlimUriFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Http\Message\UriFactory;
+
+use Http\Message\UriFactory;
+use Psr\Http\Message\UriInterface;
+use Slim\Http\Uri;
+
+/**
+ * Creates Slim 3 URI.
+ *
+ * @author Mika Tuupola <tuupola@appelsiini.net>
+ */
+final class SlimUriFactory implements UriFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createUri($uri)
+    {
+        if ($uri instanceof UriInterface) {
+            return $uri;
+        }
+
+        if (is_string($uri)) {
+            return Uri::createFromString($uri);
+        }
+
+        throw new \InvalidArgumentException('URI must be a string or UriInterface');
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | https://github.com/php-http/documentation/pull/159
| License         | MIT


#### What's in this PR?

This PR adds message, stream and URI factories for [Slim Framework](https://github.com/slimphp/Slim) 

#### Why?

Slim is reasonably popular PSR-7 based framework.

#### Example Usage

``` php
use Http\Client\Curl\Client;
use Http\Message\MessageFactory\SlimMessageFactory;
use Http\Message\StreamFactory\SlimStreamFactory;

$client = new Client(new SlimMessageFactory(), new SlimStreamFactory());
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] Should something be added to [puli.json](https://github.com/php-http/message/blob/master/puli.json)?
- [ ] Should these be named `Slim3StreamFactory` and `Slim3StreamFactory` instead?
- [ ] Should there be more tests? This was so easy I feel like I am missing something.

