### PR TITLE
Added Slim to puli.json

### DIFF
--- a/puli.json
+++ b/puli.json
@@ -10,6 +10,16 @@
                 "depends": "Zend\\Diactoros\\Request"
             }
         },
+        "0836751e-6558-4d1b-8993-4a52012947c3": {
+            "_class": "Puli\\Discovery\\Binding\\ClassBinding",
+            "class": "Http\\Message\\MessageFactory\\SlimMessageFactory",
+            "type": "Http\\Message\\ResponseFactory"
+        },
+        "1d127622-dc61-4bfa-b9da-d221548d72c3": {
+            "_class": "Puli\\Discovery\\Binding\\ClassBinding",
+            "class": "Http\\Message\\MessageFactory\\SlimMessageFactory",
+            "type": "Http\\Message\\RequestFactory"
+        },
         "2438c2d0-0658-441f-8855-ddaf0f87d54d": {
             "_class": "Puli\\Discovery\\Binding\\ClassBinding",
             "class": "Http\\Message\\MessageFactory\\GuzzleMessageFactory",
@@ -50,6 +60,11 @@
                 "depends": "Zend\\Diactoros\\Uri"
             }
         },
+        "4672a6ee-ad9e-4109-a5d1-b7d46f26c7a1": {
+            "_class": "Puli\\Discovery\\Binding\\ClassBinding",
+            "class": "Http\\Message\\MessageFactory\\SlimMessageFactory",
+            "type": "Http\\Message\\MessageFactory"
+        },
         "6234e947-d3bd-43eb-97d5-7f9e22e6bb1b": {
             "_class": "Puli\\Discovery\\Binding\\ClassBinding",
             "class": "Http\\Message\\MessageFactory\\DiactorosMessageFactory",
@@ -57,6 +72,16 @@
             "parameters": {
                 "depends": "Zend\\Diactoros\\Response"
             }
+        },
+        "6a9ad6ce-d82c-470f-8e30-60f21d9d95bf": {
+            "_class": "Puli\\Discovery\\Binding\\ClassBinding",
+            "class": "Http\\Message\\UriFactory\\SlimUriFactory",
+            "type": "Http\\Message\\UriFactory"
+        },
+        "72c2afa0-ea56-4d03-adb6-a9f241a8a734": {
+            "_class": "Puli\\Discovery\\Binding\\ClassBinding",
+            "class": "Http\\Message\\StreamFactory\\SlimStreamFactory",
+            "type": "Http\\Message\\StreamFactory"
         },
         "95c1be8f-39fe-4abd-8351-92cb14379a75": {
             "_class": "Puli\\Discovery\\Binding\\ClassBinding",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT

Slim factories need to be in puli.json. 

For future reference. This is how I did. (Ping @tuupola)
```bash
$ php puli.phar bind -f Http\\Message\\MessageFactory\\SlimMessageFactory Http\\Message\\MessageFactory
$ php puli.phar bind -f Http\\Message\\MessageFactory\\SlimMessageFactory Http\\Message\\ResponseFactory
$ php puli.phar bind -f Http\\Message\\MessageFactory\\SlimMessageFactory Http\\Message\\RequestFactory
$ php puli.phar bind -f Http\\Message\\StreamFactory\\SlimStreamFactory Http\\Message\\StreamFactory
$ php puli.phar bind -f Http\\Message\\UriFactory\\SlimUriFactory Http\\Message\\UriFactory   
```