### PR TITLE
Relax minimum required version of Slim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "henrikbjorn/phpspec-code-coverage" : "^1.0",
         "coduo/phpspec-data-provider-extension": "^1.0",
         "akeneo/phpspec-skip-example-extension": "^1.0",
-        "slim/slim": "^3.5"
+        "slim/slim": "^3.0"
     },
     "suggest": {
         "zendframework/zend-diactoros": "Used with Diactoros Factories",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | n
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in https://github.com/php-http/documentation/pull/159
| Documentation   | 
| License         | MIT


#### What's in this PR?

This relaxes the minimum require Slim Framework version from 3.5 to 3.0. This is something I forgot to change before submitting #53.


#### Why?

Slim follows semver so anything starting from 3.0 will work. Also ran tests for all 3.x versions manually and they pass. 
