### PR TITLE
Remove encoding writing stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Deprecated
+
+ - FilteredStream::getReadFilter The read filter is internal and should never be used by consuming code.
+ - FilteredStream::getWriteFilter We did not implement writing to the streams at all. And if we do, the filter is an internal information and should not be used by consuming code.
+
 ## 1.4.0 - 2016-10-20
 
 ### Added

--- a/src/Encoding/ChunkStream.php
+++ b/src/Encoding/ChunkStream.php
@@ -12,7 +12,7 @@ class ChunkStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'chunk';
     }
@@ -20,7 +20,7 @@ class ChunkStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'dechunk';
     }

--- a/src/Encoding/CompressStream.php
+++ b/src/Encoding/CompressStream.php
@@ -27,7 +27,7 @@ class CompressStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'zlib.deflate';
     }
@@ -35,7 +35,7 @@ class CompressStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'zlib.inflate';
     }

--- a/src/Encoding/DechunkStream.php
+++ b/src/Encoding/DechunkStream.php
@@ -14,7 +14,7 @@ class DechunkStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'dechunk';
     }
@@ -22,7 +22,7 @@ class DechunkStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'chunk';
     }

--- a/src/Encoding/DecompressStream.php
+++ b/src/Encoding/DecompressStream.php
@@ -27,7 +27,7 @@ class DecompressStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'zlib.inflate';
     }
@@ -35,7 +35,7 @@ class DecompressStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'zlib.deflate';
     }

--- a/src/Encoding/DeflateStream.php
+++ b/src/Encoding/DeflateStream.php
@@ -23,7 +23,7 @@ class DeflateStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'zlib.deflate';
     }
@@ -31,7 +31,7 @@ class DeflateStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'zlib.inflate';
     }

--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -24,16 +24,22 @@ abstract class FilteredStream implements StreamInterface
 
     /**
      * @var resource
+     *
+     * @deprecated since version 1.5, will be removed in 2.0
      */
     protected $readFilter;
 
     /**
      * @var callable
+     *
+     * @deprecated since version 1.5, will be removed in 2.0
      */
     protected $writeFilterCallback;
 
     /**
      * @var resource
+     *
+     * @deprecated since version 1.5, will be removed in 2.0
      */
     protected $writeFilter;
 
@@ -47,12 +53,17 @@ abstract class FilteredStream implements StreamInterface
     /**
      * @param StreamInterface $stream
      * @param mixed|null      $readFilterOptions
-     * @param mixed|null      $writeFilterOptions
+     * @param mixed|null      $writeFilterOptions deprecated since 1.5, will be removed in 2.0
      */
     public function __construct(StreamInterface $stream, $readFilterOptions = null, $writeFilterOptions = null)
     {
-        $this->readFilterCallback = Filter\fun($this->getReadFilter(), $readFilterOptions);
-        $this->writeFilterCallback = Filter\fun($this->getWriteFilter(), $writeFilterOptions);
+        $this->readFilterCallback = Filter\fun($this->readFilter(), $readFilterOptions);
+        $this->writeFilterCallback = Filter\fun($this->writeFilter(), $writeFilterOptions);
+
+        if (null !== $writeFilterOptions) {
+            @trigger_error('The $writeFilterOptions argument is deprecated since version 1.5 and will be removed in 2.0.', E_USER_DEPRECATED);
+        }
+
         $this->stream = $stream;
     }
 
@@ -139,13 +150,41 @@ abstract class FilteredStream implements StreamInterface
      * Returns the read filter name.
      *
      * @return string
+     *
+     * @deprecated since version 1.5, will be removed in 2.0
      */
-    abstract public function getReadFilter();
+    public function getReadFilter()
+    {
+        @trigger_error('The '.__CLASS__.'::'.__METHOD__.' method is deprecated since version 1.5 and will be removed in 2.0.', E_USER_DEPRECATED);
+
+        return $this->readFilter();
+    }
 
     /**
      * Returns the write filter name.
      *
      * @return string
      */
-    abstract public function getWriteFilter();
+    abstract protected function readFilter();
+
+    /**
+     * Returns the write filter name.
+     *
+     * @return string
+     *
+     * @deprecated since version 1.5, will be removed in 2.0
+     */
+    public function getWriteFilter()
+    {
+        @trigger_error('The '.__CLASS__.'::'.__METHOD__.' method is deprecated since version 1.5 and will be removed in 2.0.', E_USER_DEPRECATED);
+
+        return $this->writeFilter();
+    }
+
+    /**
+     * Returns the write filter name.
+     *
+     * @return string
+     */
+    abstract protected function writeFilter();
 }

--- a/src/Encoding/GzipDecodeStream.php
+++ b/src/Encoding/GzipDecodeStream.php
@@ -27,7 +27,7 @@ class GzipDecodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'zlib.inflate';
     }
@@ -35,7 +35,7 @@ class GzipDecodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'zlib.deflate';
     }

--- a/src/Encoding/GzipEncodeStream.php
+++ b/src/Encoding/GzipEncodeStream.php
@@ -27,7 +27,7 @@ class GzipEncodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'zlib.deflate';
     }
@@ -35,7 +35,7 @@ class GzipEncodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'zlib.inflate';
     }

--- a/src/Encoding/InflateStream.php
+++ b/src/Encoding/InflateStream.php
@@ -27,7 +27,7 @@ class InflateStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getReadFilter()
+    protected function readFilter()
     {
         return 'zlib.inflate';
     }
@@ -35,7 +35,7 @@ class InflateStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    public function getWriteFilter()
+    protected function writeFilter()
     {
         return 'zlib.deflate';
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| BC breaks?      | no
| Deprecations?   | yes
| License         | MIT


#### What's in this PR?

This PR removes all stuff related with write filters in the `Http\Message\Encoding` namespace.


#### Why?

The abstract class `Http\Message\Encoding\FilteredStream` defines an abstract method named `getWriteFilter` that is not called anywhere and produces dead code not being tested. IMO this code must be removed or at least deprecated.


#### Example Usage

You can run the tests to see that this code is not being used nor tested.
``` 
$composer test
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [x] Squash the commits before merge

