### PR TITLE
Fix encoding stream size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixed
+
+ - FilteredStream::getSize returns null because the contents size is unknown.
+
 ### Deprecated
 
  - FilteredStream::getReadFilter The read filter is internal and should never be used by consuming code.

--- a/spec/Encoding/ChunkStreamSpec.php
+++ b/spec/Encoding/ChunkStreamSpec.php
@@ -39,4 +39,12 @@ class ChunkStreamSpec extends ObjectBehavior
 
         $this->getContents()->shouldReturn("6\r\nThis i\r\n6\r\ns a st\r\n4\r\nream\r\n0\r\n\r\n");
     }
+
+    function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream('This is a stream');
+        $this->beConstructedWith($stream, 6);
+
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/spec/Encoding/CompressStreamSpec.php
+++ b/spec/Encoding/CompressStreamSpec.php
@@ -41,4 +41,13 @@ class CompressStreamSpec extends ObjectBehavior
         $stream->rewind();
         $this->getContents()->shouldReturn(gzcompress('This is a test stream'));
     }
+
+    function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream('This is a test stream');
+        $this->beConstructedWith($stream);
+
+        $stream->rewind();
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/spec/Encoding/DechunkStreamSpec.php
+++ b/spec/Encoding/DechunkStreamSpec.php
@@ -40,4 +40,12 @@ class DechunkStreamSpec extends ObjectBehavior
 
         $this->getContents()->shouldReturn('test');
     }
+
+        function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream("4\r\ntest\r\n4\r\ntest\r\n0\r\n\r\n\0");
+        $this->beConstructedWith($stream);
+
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/spec/Encoding/DecompressStreamSpec.php
+++ b/spec/Encoding/DecompressStreamSpec.php
@@ -41,4 +41,12 @@ class DecompressStreamSpec extends ObjectBehavior
 
         $this->getContents()->shouldReturn('This is a test stream');
     }
+
+    function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream(gzcompress('This is a test stream'));
+        $this->beConstructedWith($stream);
+
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/spec/Encoding/DeflateStreamSpec.php
+++ b/spec/Encoding/DeflateStreamSpec.php
@@ -36,4 +36,12 @@ class DeflateStreamSpec extends ObjectBehavior
         $stream->rewind();
         $this->getContents()->shouldReturn(gzdeflate('This is a test stream'));
     }
+
+    function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream('This stream is a test stream');
+        $this->beConstructedWith($stream);
+
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/spec/Encoding/GzipDecodeStreamSpec.php
+++ b/spec/Encoding/GzipDecodeStreamSpec.php
@@ -41,4 +41,12 @@ class GzipDecodeStreamSpec extends ObjectBehavior
 
         $this->getContents()->shouldReturn('This is a test stream');
     }
+
+    function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream(gzencode('This is a test stream'));
+        $this->beConstructedWith($stream);
+
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/spec/Encoding/GzipEncodeStreamSpec.php
+++ b/spec/Encoding/GzipEncodeStreamSpec.php
@@ -41,4 +41,13 @@ class GzipEncodeStreamSpec extends ObjectBehavior
         $stream->rewind();
         $this->getContents()->shouldReturn(gzencode('This is a test stream'));
     }
+
+    function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream('This is a test stream');
+        $this->beConstructedWith($stream);
+
+        $stream->rewind();
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/spec/Encoding/InflateStreamSpec.php
+++ b/spec/Encoding/InflateStreamSpec.php
@@ -36,4 +36,12 @@ class InflateStreamSpec extends ObjectBehavior
 
         $this->getContents()->shouldReturn('This is a test stream');
     }
+
+    function it_does_not_know_the_content_size()
+    {
+        $stream = new MemoryStream(gzdeflate('This stream is a test stream'));
+        $this->beConstructedWith($stream);
+
+        $this->getSize()->shouldReturn(null);
+    }
 }

--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -141,6 +141,14 @@ abstract class FilteredStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
+    public function getSize()
+    {
+        return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function __toString()
     {
         return $this->getContents();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets | fixes #60 |
| License | MIT |
#### What's in this PR?

This PR includes the tests required to expose the problem described in #60 about the invalid `getSize` returned value by `FilteredStream` subclasses, and should include a fix.
#### Why?
#60 Invalid value returned by FilteredStream::getSize
#### Checklist
- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
#### To Do
- [x] Discuss and find a solution to fix the tests
- [x] Squash commits
