### PR TITLE
Fix cookie root path match for subdirectories. Refs #65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Cookie::matchPath Cookie with root path (`/`) will not match sub path (e.g. `/cookie`).
+
 ### Deprecated
 
  - FilteredStream::getReadFilter The read filter is internal and should never be used by consuming code.

--- a/spec/CookieSpec.php
+++ b/spec/CookieSpec.php
@@ -189,6 +189,7 @@ class CookieSpec extends ObjectBehavior
         $this->beConstructedWith('name', 'value', null, null, '/path/to/somewhere');
 
         $this->matchPath('/path/to/somewhere')->shouldReturn(true);
+        $this->matchPath('/path/to/somewhere/else')->shouldReturn(true);
         $this->matchPath('/path/to/somewhereelse')->shouldReturn(false);
     }
 
@@ -197,6 +198,8 @@ class CookieSpec extends ObjectBehavior
         $this->beConstructedWith('name', 'value', null, null, '/');
 
         $this->matchPath('/')->shouldReturn(true);
+        $this->matchPath('/cookies')->shouldReturn(true);
+        $this->matchPath('/cookies/')->shouldReturn(true);
     }
 
     function it_is_secure()

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -313,7 +313,7 @@ final class Cookie
      */
     public function matchPath($path)
     {
-        return $this->path === $path || (strpos($path, $this->path.'/') === 0);
+        return $this->path === $path || (strpos($path, rtrim($this->path, '/').'/') === 0);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no?
| Deprecations?   | no
| Related tickets | fixes #65
| License         | MIT


#### What's in this PR?

Fixes the problem where `(new Cookie('foo', 'bar', null, null, '/'))->matchPath('/cookie')` would return `false`.


#### Checklist

- [x] Updated CHANGELOG.md to describe bugfix