### PR TITLE
Add check for empty string to stream factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+## Added
+
+- Check for empty string in Stream factories
+
 ## Fixed
 
  - FilteredStream::getSize returns null because the contents size is unknown.

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -24,7 +24,7 @@ final class DiactorosStreamFactory implements StreamFactory
             } else {
                 $stream = new Stream('php://memory', 'rw');
 
-                if (null !== $body) {
+                if (null !== $body || '' !== $body) {
                     $stream->write((string) $body);
                 }
 

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -24,9 +24,11 @@ final class DiactorosStreamFactory implements StreamFactory
             } else {
                 $stream = new Stream('php://memory', 'rw');
 
-                if (null !== $body || '' !== $body) {
-                    $stream->write((string) $body);
+                if (null === $body || '' === $body) {
+                    return $stream;
                 }
+
+                $stream->write((string) $body);
 
                 $body = $stream;
             }

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -28,9 +28,11 @@ final class SlimStreamFactory implements StreamFactory
             $resource = fopen('php://memory', 'r+');
             $stream = new Stream($resource);
 
-            if (null !== $body || '' !== $body) {
-                $stream->write((string) $body);
+            if (null === $body || '' === $body) {
+                return $stream;
             }
+
+            $stream->write((string) $body);
         }
 
         $stream->rewind();

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -28,7 +28,7 @@ final class SlimStreamFactory implements StreamFactory
             $resource = fopen('php://memory', 'r+');
             $stream = new Stream($resource);
 
-            if (null !== $body) {
+            if (null !== $body || '' !== $body) {
                 $stream->write((string) $body);
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #69
| Documentation   | does not apply
| License         | MIT


#### What's in this PR?

Stream factories now check empty strings as well, not just  null values.

