### PR TITLE
Do not rewind streams

### DIFF
--- a/spec/StreamFactory/StreamFactoryBehavior.php
+++ b/spec/StreamFactory/StreamFactoryBehavior.php
@@ -36,24 +36,24 @@ trait StreamFactoryBehavior
             ->shouldHaveType('Psr\Http\Message\StreamInterface');
     }
 
-    function it_rewinds_existing_stream()
+    function it_does_not_rewind_existing_stream()
     {
         $stream = new Stream(fopen('php://memory', 'rw'));
         $stream->write('abcdef');
-        $stream->read(3);
+        $stream->seek(3);
 
         $this->createStream($stream)
-            ->shouldHaveContent('abcdef');
+            ->shouldHaveContent('def');
     }
 
-    function it_rewinds_existing_resource()
+    function it_does_not_rewind_existing_resource()
     {
         $resource = fopen('php://memory', 'rw');
         fwrite($resource, 'abcdef');
-        fread($resource, 3);
+        fseek($resource, 3);
 
         $this->createStream($resource)
-            ->shouldHaveContent('abcdef');
+            ->shouldHaveContent('def');
     }
 
     public function getMatchers()

--- a/spec/StreamFactory/StreamFactoryBehavior.php
+++ b/spec/StreamFactory/StreamFactoryBehavior.php
@@ -2,6 +2,9 @@
 
 namespace spec\Http\Message\StreamFactory;
 
+use GuzzleHttp\Psr7\Stream;
+use Psr\Http\Message\StreamInterface;
+
 trait StreamFactoryBehavior
 {
     function it_is_a_stream_factory()
@@ -31,5 +34,34 @@ trait StreamFactoryBehavior
         $resource = fopen($url, 'r');
         $this->createStream($resource)
             ->shouldHaveType('Psr\Http\Message\StreamInterface');
+    }
+
+    function it_rewinds_existing_stream()
+    {
+        $stream = new Stream(fopen('php://memory', 'rw'));
+        $stream->write('abcdef');
+        $stream->read(3);
+
+        $this->createStream($stream)
+            ->shouldHaveContent('abcdef');
+    }
+
+    function it_rewinds_existing_resource()
+    {
+        $resource = fopen('php://memory', 'rw');
+        fwrite($resource, 'abcdef');
+        fread($resource, 3);
+
+        $this->createStream($resource)
+            ->shouldHaveContent('abcdef');
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveContent' => function (StreamInterface $subject, $key) {
+                return $subject->getContents() === $key;
+            },
+        ];
     }
 }

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -18,26 +18,19 @@ final class DiactorosStreamFactory implements StreamFactory
      */
     public function createStream($body = null)
     {
-        if (!$body instanceof StreamInterface) {
-            if (is_resource($body)) {
-                $body = new Stream($body);
-            } else {
-                $stream = new Stream('php://memory', 'rw');
-
-                if (null === $body || '' === $body) {
-                    return $stream;
-                }
-
-                $stream->write((string) $body);
-
-                $body = $stream;
-            }
+        if ($body instanceof StreamInterface) {
+            return $body;
         }
 
-        if ($body->isSeekable()) {
-            $body->rewind();
+        if (is_resource($body)) {
+            return new Stream($body);
         }
 
-        return $body;
+        $stream = new Stream('php://memory', 'rw');
+        if (null !== $body && '' !== $body) {
+            $stream->write((string) $body);
+        }
+
+        return $stream;
     }
 }

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -23,20 +23,13 @@ final class SlimStreamFactory implements StreamFactory
         }
 
         if (is_resource($body)) {
-            $stream = new Stream($body);
-        } else {
-            $resource = fopen('php://memory', 'r+');
-            $stream = new Stream($resource);
-
-            if (null === $body || '' === $body) {
-                return $stream;
-            }
-
-            $stream->write((string) $body);
+            return new Stream($body);
         }
 
-        if ($stream->isSeekable()) {
-            $stream->rewind();
+        $resource = fopen('php://memory', 'r+');
+        $stream = new Stream($resource);
+        if (null !== $body && '' !== $body) {
+            $stream->write((string) $body);
         }
 
         return $stream;


### PR DESCRIPTION
Should we rewind streams and resources when they are passed in the factory? 

Guzzle does not rewind at all. 
Slim rewinds resources but not streams.
Zend rewinds everything. 

This is related to #71