### PR TITLE
Prevent false positive triggering of deprecated notice in FilteredStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 - CookieUtil::parseDate to create a date from cookie date string
 
+### Fixed
+
+- Normalize the `$writeFilterOptions` argument of the constructor of the FilteredStream class to prevent triggering
+  of a deprecated error message with some false positive cases.
+
 ## 1.5.0 - 2017-02-14
 
 ### Added

--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -57,10 +57,22 @@ abstract class FilteredStream implements StreamInterface
      */
     public function __construct(StreamInterface $stream, $readFilterOptions = null, $writeFilterOptions = null)
     {
+        $triggerDeprecationNotice = null !== $writeFilterOptions;
+
+        if (null === $readFilterOptions && in_array($this->readFilter(), ['convert.base64-encode', 'convert.base64-decode', 'convert.quoted-printable-encode', 'zlib.deflate', 'zlib.inflate'/*, 'bzip2.compress', 'bzip2.decompress'*/], true)) {
+            $readFilterOptions = [];
+        }
+
+        if (null === $writeFilterOptions && in_array($this->writeFilter(), ['convert.base64-encode', 'convert.base64-decode', 'convert.quoted-printable-encode', 'zlib.deflate', 'zlib.inflate'/*, 'bzip2.compress', 'bzip2.decompress'*/], true)) {
+            $writeFilterOptions = [];
+
+            $triggerDeprecationNotice = false;
+        }
+
         $this->readFilterCallback = Filter\fun($this->readFilter(), $readFilterOptions);
         $this->writeFilterCallback = Filter\fun($this->writeFilter(), $writeFilterOptions);
 
-        if (null !== $writeFilterOptions) {
+        if ($triggerDeprecationNotice) {
             @trigger_error('The $writeFilterOptions argument is deprecated since version 1.5 and will be removed in 2.0.', E_USER_DEPRECATED);
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #78
| License         | MIT


#### What's in this PR?

In this PR the `$writeFilterOptions` argument of the `FilteredStream::__construct` method is normalized because some built-in PHP stream filters doesn't accept `null` as options. As a consequence of this, the deprecation message was triggered in some cases when it should not had to, and this has been addressed too. I'm not sure about the entry I added in the CHANGELOG, as I'm not a native English speaker maybe you can find a better phrase... I don't know if unit tests are needed for this PR as currently there is nothing hat tests the throwing of the error or the call to the `Filter\fun` function with the correct arguments. Ast a last thing, I can't test what options the `bzip2.compress` and `bzip2.decompress` accept, so the PR is not ready yet until someone finds out if `null` is a valid value or not.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix