### PR TITLE
Fix curl command of CurlFormatter when there is an user-agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - CookieUtil::parseDate to create a date from cookie date string
 
+### Fixed
+
+- Fix curl command of CurlFormatter when there is an user-agent header   
+
 ## 1.5.0 - 2017-02-14
 
 ### Added

--- a/spec/Formatter/CurlCommandFormatterSpec.php
+++ b/spec/Formatter/CurlCommandFormatterSpec.php
@@ -58,4 +58,18 @@ class CurlCommandFormatterSpec extends ObjectBehavior
     {
         $this->formatResponse($response)->shouldReturn('');
     }
+
+    function it_formats_the_request_with_user_agent(RequestInterface $request, UriInterface $uri, StreamInterface $body)
+    {
+        $request->getUri()->willReturn($uri);
+        $request->getBody()->willReturn($body);
+
+        $uri->withFragment('')->shouldBeCalled()->willReturn('http://foo.com/bar');
+        $request->getMethod()->willReturn('GET');
+        $request->getProtocolVersion()->willReturn('1.1');
+        $uri->withFragment('')->shouldBeCalled()->willReturn('http://foo.com/bar');
+        $request->getHeaders()->willReturn(['user-agent'=>['foobar-browser']]);
+
+        $this->formatRequest($request)->shouldReturn("curl 'http://foo.com/bar' -A 'foobar-browser'");
+    }
 }

--- a/src/Formatter/CurlCommandFormatter.php
+++ b/src/Formatter/CurlCommandFormatter.php
@@ -68,7 +68,7 @@ class CurlCommandFormatter implements Formatter
             }
 
             if ('user-agent' === strtolower($name)) {
-                $command .= sprintf('-A %s', escapeshellarg($values[0]));
+                $command .= sprintf(' -A %s', escapeshellarg($values[0]));
                 continue;
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

The curl formatter display an invalid curl command when the request has an user-agent header


#### Why?

Instead of this curl command

```
curl 'http://example.com' --head-A 'Mozilla/5.0'
```

the formatter should format like this:

```
curl 'http://example.com' --head -A 'Mozilla/5.0'
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
