### PR TITLE
Cookie.php fixed invalid PHPDoc

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -56,7 +56,7 @@ final class Cookie
     /**
      * @param string         $name
      * @param string|null    $value
-     * @param int            $maxAge
+     * @param int|null       $maxAge
      * @param string|null    $domain
      * @param string|null    $path
      * @param bool           $secure


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | none
| License         | MIT


#### What's in this PR?

Fix for invalid PHPDoc


#### Why?

Parameter $maxAge is nullable and its PHPDoc should reflect that.


#### Example Usage

none


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

none
