### PR TITLE
Improve formatting of requests with binary streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## Unreleased
+
+### Fixed
+
+- Fix CurlCommandFormatter for binary request payloads
+
+
 ## 1.6.0 - 2017-07-05
 
 ### Added

--- a/src/Formatter/CurlCommandFormatter.php
+++ b/src/Formatter/CurlCommandFormatter.php
@@ -36,11 +36,16 @@ class CurlCommandFormatter implements Formatter
 
         $body = $request->getBody();
         if ($body->getSize() > 0) {
-            if (!$body->isSeekable()) {
-                return 'Cant format Request as cUrl command if body stream is not seekable.';
+            if ($body->isSeekable()) {
+                $data = $body->__toString();
+                $body->rewind();
+                if (preg_match('/[\x00-\x1F\x7F]/', $data)) {
+                    $data = '[binary stream omitted]';
+                }
+            } else {
+                $data = '[non-seekable stream omitted]';
             }
-            $command .= sprintf(' --data %s', escapeshellarg($body->__toString()));
-            $body->rewind();
+            $command .= sprintf(' --data %s', escapeshellarg($data));
         }
 
         return $command;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #91 
| Documentation   | -
| License         | MIT


#### What's in this PR?

This PR fixes the handling of null bytes in  `CurlCommandFormatter`. Up to now, an exception is thrown in `escapeshellarg`. In addition, non-seekable streams get formatted in the same manner.


#### Example Usage

Requests containing null bytes are formatted as follows:
```bash
curl 'http://foo.com/bar' --request POST --data '[binary stream omitted]'
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [ ] At the moment, as soon as any control character (including \n) is detected, the payload is omitted. If we want to keep them we would probably have to implement platform-dependent escaping routines to output a one-liner. `escapeshellarg()` doesn't help as it would just pass all control characters (except \0). An example of such routines can be found in [Chromium](https://chromium.googlesource.com/chromium/src/third_party/WebKit/Source/devtools/+/b1ca46eaea6d50c9d5068eeb8dda4dbffd8cd321/front_end/network/NetworkLogView.js#1638).
- [ ] Should we limit the size of the body too? I think it's rarely useful to dump megabytes of data even if there are no null bytes.
