### PR TITLE
Fix implementation of __toString()

### DIFF
--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -154,6 +154,7 @@ abstract class FilteredStream implements StreamInterface
         if ($this->stream->isSeekable()) {
             $this->stream->rewind();
         }
+
         return $this->getContents();
     }
 

--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -151,6 +151,9 @@ abstract class FilteredStream implements StreamInterface
      */
     public function __toString()
     {
+        if ($this->stream->isSeekable()) {
+            $this->stream->rewind();
+        }
         return $this->getContents();
     }
 


### PR DESCRIPTION
"This method MUST attempt to seek to the beginning of the stream before reading data and read the stream until the end is reached."

https://github.com/php-fig/http-message/blob/master/src/StreamInterface.php#L28

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no

#### What's in this PR?

This is a followup on this bug reported for the client-common package: https://github.com/php-http/client-common/issues/98
