### PR TITLE
Force proper arg separator to avoid composing broken URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - Fix CurlCommandFormatter for binary request payloads
+- Fix QueryParam authentication to assemble proper URL regardless of PHP `arg_separator.output` directive
 
 
 ## 1.6.0 - 2017-07-05

--- a/src/Authentication/QueryParam.php
+++ b/src/Authentication/QueryParam.php
@@ -41,7 +41,7 @@ final class QueryParam implements Authentication
 
         $params = array_merge($params, $this->params);
 
-        $query = http_build_query($params);
+        $query = http_build_query($params, null, '&');
 
         $uri = $uri->withQuery($query);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   |-
| License         | MIT

#### What's in this PR?

Make sure `http_build_query()` uses `&` as argument separator when assemble query params in URL.

#### Why?

By default, `http_build_query()` uses [arg_separator.output](http://php.net/manual/en/ini.core.php#ini.arg-separator.output) from php.ini. But this may be set to anything (most often `&amp;` because of some legacy apps), which will then silently break URLs assembled by the plugin.

For example Guzzle [does](https://github.com/guzzle/guzzle/blob/f3504c44a81f4604074bf26946c3a65c9f03a704/src/Client.php#L371) this as well by default when assembling query strings.

Without the fix this also obviously breaks unit tests when run on our system:
```
----  broken examples

        Http/Message/Authentication/QueryParam
  29  ! authenticates a request
        method call:
          - withQuery("param1=value1&amp;param2%5B0%5D=value2&amp;userna"...)
        on Double\UriInterface\P34 was not expected, expected calls were:
          - getQuery()
          - withQuery(exact("param1=value1&param2%5B0%5D=value2&username=usern"...))
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
