### PR TITLE
drop hhvm support as its no longer working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
     include:
         - php: 5.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
-        - php: hhvm
-          dist: trusty
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.4 || ^7.0",
         "psr/http-message": "^1.0",
         "php-http/message-factory": "^1.0.2",
         "clue/stream-filter": "^1.4"

--- a/spec/Encoding/ChunkStreamSpec.php
+++ b/spec/Encoding/ChunkStreamSpec.php
@@ -12,10 +12,6 @@ class ChunkStreamSpec extends ObjectBehavior
 
     function let(StreamInterface $stream)
     {
-        if (defined('HHVM_VERSION')) {
-            throw new SkippingException('Skipping test as there is no dechunk filter on hhvm');
-        }
-
         $this->beConstructedWith($stream);
     }
 

--- a/spec/Encoding/CompressStreamSpec.php
+++ b/spec/Encoding/CompressStreamSpec.php
@@ -12,10 +12,6 @@ class CompressStreamSpec extends ObjectBehavior
 
     function let(StreamInterface $stream)
     {
-        if (defined('HHVM_VERSION')) {
-            throw new SkippingException('Skipping test as zlib is not working on hhvm');
-        }
-
         $this->beConstructedWith($stream);
     }
 

--- a/spec/Encoding/DechunkStreamSpec.php
+++ b/spec/Encoding/DechunkStreamSpec.php
@@ -12,10 +12,6 @@ class DechunkStreamSpec extends ObjectBehavior
 
     function let(StreamInterface $stream)
     {
-        if (defined('HHVM_VERSION')) {
-            throw new SkippingException('Skipping test as there is no dechunk filter on hhvm');
-        }
-
         $this->beConstructedWith($stream);
     }
 

--- a/spec/Encoding/DecompressStreamSpec.php
+++ b/spec/Encoding/DecompressStreamSpec.php
@@ -12,10 +12,6 @@ class DecompressStreamSpec extends ObjectBehavior
 
     function let(StreamInterface $stream)
     {
-        if (defined('HHVM_VERSION')) {
-            throw new SkippingException('Skipping test as zlib is not working on hhvm');
-        }
-
         $this->beConstructedWith($stream);
     }
 

--- a/spec/Encoding/GzipDecodeStreamSpec.php
+++ b/spec/Encoding/GzipDecodeStreamSpec.php
@@ -12,10 +12,6 @@ class GzipDecodeStreamSpec extends ObjectBehavior
 
     function let(StreamInterface $stream)
     {
-        if (defined('HHVM_VERSION')) {
-            throw new SkippingException('Skipping test as zlib is not working on hhvm');
-        }
-
         $this->beConstructedWith($stream);
     }
 

--- a/spec/Encoding/GzipEncodeStreamSpec.php
+++ b/spec/Encoding/GzipEncodeStreamSpec.php
@@ -12,10 +12,6 @@ class GzipEncodeStreamSpec extends ObjectBehavior
 
     function let(StreamInterface $stream)
     {
-        if (defined('HHVM_VERSION')) {
-            throw new SkippingException('Skipping test as zlib is not working on hhvm');
-        }
-
         $this->beConstructedWith($stream);
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Drop HHVM support


#### Why?

Builds with hhvm started failing. HHVM is not used much anymore, so i'd rather drop support for it than trying to figure out how to fix the build with it.
