### PR TITLE
Filtered Stream is not seekable

### DIFF
--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -155,6 +155,30 @@ abstract class FilteredStream implements StreamInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        throw new \RuntimeException('Cannot rewind a filtered stream');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        throw new \RuntimeException('Cannot seek a filtered stream');
+    }
+
+    /**
      * Returns the read filter name.
      *
      * @return string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | replace #95, fixes #90
| Documentation   | 
| License         | MIT

Filtered Stream is not seekable, previously we would rely on the inner stream, but it was a mistake.
