### PR TITLE
Remove internal deprecation notice

### DIFF
--- a/src/Encoding/CompressStream.php
+++ b/src/Encoding/CompressStream.php
@@ -2,6 +2,7 @@
 
 namespace Http\Message\Encoding;
 
+use Clue\StreamFilter as Filter;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -21,7 +22,10 @@ class CompressStream extends FilteredStream
             throw new \RuntimeException('The zlib extension must be enabled to use this stream');
         }
 
-        parent::__construct($stream, ['window' => 15, 'level' => $level], ['window' => 15]);
+        parent::__construct($stream, ['window' => 15, 'level' => $level]);
+
+        // @deprecated will be removed in 2.0
+        $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => 15]);
     }
 
     /**

--- a/src/Encoding/DecompressStream.php
+++ b/src/Encoding/DecompressStream.php
@@ -2,6 +2,7 @@
 
 namespace Http\Message\Encoding;
 
+use Clue\StreamFilter as Filter;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -21,7 +22,10 @@ class DecompressStream extends FilteredStream
             throw new \RuntimeException('The zlib extension must be enabled to use this stream');
         }
 
-        parent::__construct($stream, ['window' => 15], ['window' => 15, 'level' => $level]);
+        parent::__construct($stream, ['window' => 15]);
+
+        // @deprecated will be removed in 2.0
+        $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => 15, 'level' => $level]);
     }
 
     /**

--- a/src/Encoding/DeflateStream.php
+++ b/src/Encoding/DeflateStream.php
@@ -2,6 +2,7 @@
 
 namespace Http\Message\Encoding;
 
+use Clue\StreamFilter as Filter;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -17,7 +18,10 @@ class DeflateStream extends FilteredStream
      */
     public function __construct(StreamInterface $stream, $level = -1)
     {
-        parent::__construct($stream, ['window' => -15, 'level' => $level], ['window' => -15]);
+        parent::__construct($stream, ['window' => -15, 'level' => $level]);
+
+        // @deprecated will be removed in 2.0
+        $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => -15]);
     }
 
     /**

--- a/src/Encoding/GzipDecodeStream.php
+++ b/src/Encoding/GzipDecodeStream.php
@@ -2,6 +2,7 @@
 
 namespace Http\Message\Encoding;
 
+use Clue\StreamFilter as Filter;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -21,7 +22,10 @@ class GzipDecodeStream extends FilteredStream
             throw new \RuntimeException('The zlib extension must be enabled to use this stream');
         }
 
-        parent::__construct($stream, ['window' => 31], ['window' => 31, 'level' => $level]);
+        parent::__construct($stream, ['window' => 31]);
+
+        // @deprecated will be removed in 2.0
+        $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => 31, 'level' => $level]);
     }
 
     /**

--- a/src/Encoding/GzipEncodeStream.php
+++ b/src/Encoding/GzipEncodeStream.php
@@ -2,6 +2,7 @@
 
 namespace Http\Message\Encoding;
 
+use Clue\StreamFilter as Filter;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -21,7 +22,10 @@ class GzipEncodeStream extends FilteredStream
             throw new \RuntimeException('The zlib extension must be enabled to use this stream');
         }
 
-        parent::__construct($stream, ['window' => 31, 'level' => $level], ['window' => 31]);
+        parent::__construct($stream, ['window' => 31, 'level' => $level]);
+
+        // @deprecated will be removed in 2.0
+        $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => 31]);
     }
 
     /**

--- a/src/Encoding/InflateStream.php
+++ b/src/Encoding/InflateStream.php
@@ -2,6 +2,7 @@
 
 namespace Http\Message\Encoding;
 
+use Clue\StreamFilter as Filter;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -21,7 +22,10 @@ class InflateStream extends FilteredStream
             throw new \RuntimeException('The zlib extension must be enabled to use this stream');
         }
 
-        parent::__construct($stream, ['window' => -15], ['window' => -15, 'level' => $level]);
+        parent::__construct($stream, ['window' => -15]);
+
+        // @deprecated will be removed in 2.0
+        $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => -15, 'level' => $level]);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #78 
| Documentation   | 
| License         | MIT

This remove internal deprecation notices and still respect bc promise, by implementing construct in each implementation.
