### PR TITLE
trigger_error instead of exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [1.7.2] - 2018-10-30
+
+### Fixed
+
+- FilteredStream uses `@trigger_error` instead of throwing exceptions to not
+  break careless users. You still need to fix your stream code to respect
+  `isSeekable`. Seeking does not work as expected, and we will add exceptions
+  in version 2.
 
 ## [1.7.1] - 2018-10-29
 

--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -15,7 +15,10 @@ abstract class FilteredStream implements StreamInterface
 {
     const BUFFER_SIZE = 8192;
 
-    use StreamDecorator;
+    use StreamDecorator {
+        rewind as private doRewind;
+        seek as private doSeek;
+    }
 
     /**
      * @var callable
@@ -146,11 +149,11 @@ abstract class FilteredStream implements StreamInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Always returns null because we can't tell the size of a stream when we filter.
      */
     public function getSize()
     {
-        return;
+        return null;
     }
 
     /**
@@ -162,7 +165,9 @@ abstract class FilteredStream implements StreamInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Filtered streams are not seekable.
+     *
+     * We would need to buffer and process everything to allow seeking.
      */
     public function isSeekable()
     {
@@ -174,7 +179,8 @@ abstract class FilteredStream implements StreamInterface
      */
     public function rewind()
     {
-        throw new \RuntimeException('Cannot rewind a filtered stream');
+        @trigger_error('Filtered streams are not seekable. This method will start raising an exception in the next major version', E_USER_DEPRECATED);
+        $this->doRewind();
     }
 
     /**
@@ -182,7 +188,8 @@ abstract class FilteredStream implements StreamInterface
      */
     public function seek($offset, $whence = SEEK_SET)
     {
-        throw new \RuntimeException('Cannot seek a filtered stream');
+        @trigger_error('Filtered streams are not seekable. This method will start raising an exception in the next major version', E_USER_DEPRECATED);
+        $this->doSeek($offset, $whence);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | reverts BC break of #100
| Deprecations?   | yes
| Related tickets | fixes #100 
| Documentation   | -
| License         | MIT


#### What's in this PR?

Use trigger_error rather than throw exceptions


#### Why?

Consumers SHOULD are supposed to check `isSeekable` and only seek/rewind if that returns true, but it seems they don't all do that. 



#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
