### PR TITLE
Added deprecation notification on our factories

### DIFF
--- a/src/MessageFactory/DiactorosMessageFactory.php
+++ b/src/MessageFactory/DiactorosMessageFactory.php
@@ -11,6 +11,7 @@ use Zend\Diactoros\Response;
  * Creates Diactoros messages.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosMessageFactory implements MessageFactory
 {

--- a/src/MessageFactory/DiactorosMessageFactory.php
+++ b/src/MessageFactory/DiactorosMessageFactory.php
@@ -12,7 +12,7 @@ use Zend\Diactoros\Response;
  *
  * @author GeLo <geloen.eric@gmail.com>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosMessageFactory implements MessageFactory
 {

--- a/src/MessageFactory/DiactorosMessageFactory.php
+++ b/src/MessageFactory/DiactorosMessageFactory.php
@@ -11,6 +11,7 @@ use Zend\Diactoros\Response;
  * Creates Diactoros messages.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosMessageFactory implements MessageFactory

--- a/src/MessageFactory/GuzzleMessageFactory.php
+++ b/src/MessageFactory/GuzzleMessageFactory.php
@@ -10,6 +10,7 @@ use Http\Message\MessageFactory;
  * Creates Guzzle messages.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleMessageFactory implements MessageFactory
 {

--- a/src/MessageFactory/GuzzleMessageFactory.php
+++ b/src/MessageFactory/GuzzleMessageFactory.php
@@ -10,6 +10,7 @@ use Http\Message\MessageFactory;
  * Creates Guzzle messages.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleMessageFactory implements MessageFactory

--- a/src/MessageFactory/GuzzleMessageFactory.php
+++ b/src/MessageFactory/GuzzleMessageFactory.php
@@ -11,7 +11,7 @@ use Http\Message\MessageFactory;
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleMessageFactory implements MessageFactory
 {

--- a/src/MessageFactory/SlimMessageFactory.php
+++ b/src/MessageFactory/SlimMessageFactory.php
@@ -14,7 +14,7 @@ use Slim\Http\Headers;
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimMessageFactory implements MessageFactory
 {

--- a/src/MessageFactory/SlimMessageFactory.php
+++ b/src/MessageFactory/SlimMessageFactory.php
@@ -13,6 +13,7 @@ use Slim\Http\Headers;
  * Creates Slim 3 messages.
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
+ * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimMessageFactory implements MessageFactory
 {

--- a/src/MessageFactory/SlimMessageFactory.php
+++ b/src/MessageFactory/SlimMessageFactory.php
@@ -13,6 +13,7 @@ use Slim\Http\Headers;
  * Creates Slim 3 messages.
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimMessageFactory implements MessageFactory

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -11,7 +11,7 @@ use Zend\Diactoros\Stream;
  *
  * @author Михаил Красильников <m.krasilnikov@yandex.ru>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosStreamFactory implements StreamFactory
 {

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -10,6 +10,7 @@ use Zend\Diactoros\Stream;
  * Creates Diactoros streams.
  *
  * @author Михаил Красильников <m.krasilnikov@yandex.ru>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosStreamFactory implements StreamFactory

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -10,6 +10,7 @@ use Zend\Diactoros\Stream;
  * Creates Diactoros streams.
  *
  * @author Михаил Красильников <m.krasilnikov@yandex.ru>
+ * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosStreamFactory implements StreamFactory
 {

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -8,6 +8,7 @@ use Http\Message\StreamFactory;
  * Creates Guzzle streams.
  *
  * @author Михаил Красильников <m.krasilnikov@yandex.ru>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleStreamFactory implements StreamFactory

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -8,6 +8,7 @@ use Http\Message\StreamFactory;
  * Creates Guzzle streams.
  *
  * @author Михаил Красильников <m.krasilnikov@yandex.ru>
+ * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleStreamFactory implements StreamFactory
 {

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -9,7 +9,7 @@ use Http\Message\StreamFactory;
  *
  * @author Михаил Красильников <m.krasilnikov@yandex.ru>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleStreamFactory implements StreamFactory
 {

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -11,7 +11,7 @@ use Slim\Http\Stream;
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimStreamFactory implements StreamFactory
 {

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -10,6 +10,7 @@ use Slim\Http\Stream;
  * Creates Slim 3 streams.
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimStreamFactory implements StreamFactory

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -10,6 +10,7 @@ use Slim\Http\Stream;
  * Creates Slim 3 streams.
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
+ * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimStreamFactory implements StreamFactory
 {

--- a/src/UriFactory/DiactorosUriFactory.php
+++ b/src/UriFactory/DiactorosUriFactory.php
@@ -10,6 +10,7 @@ use Zend\Diactoros\Uri;
  * Creates Diactoros URI.
  *
  * @author David de Boer <david@ddeboer.nl>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosUriFactory implements UriFactory

--- a/src/UriFactory/DiactorosUriFactory.php
+++ b/src/UriFactory/DiactorosUriFactory.php
@@ -10,6 +10,7 @@ use Zend\Diactoros\Uri;
  * Creates Diactoros URI.
  *
  * @author David de Boer <david@ddeboer.nl>
+ * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosUriFactory implements UriFactory
 {

--- a/src/UriFactory/DiactorosUriFactory.php
+++ b/src/UriFactory/DiactorosUriFactory.php
@@ -11,7 +11,7 @@ use Zend\Diactoros\Uri;
  *
  * @author David de Boer <david@ddeboer.nl>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Diactoros PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Diactoros PSR-17 factory
  */
 final class DiactorosUriFactory implements UriFactory
 {

--- a/src/UriFactory/GuzzleUriFactory.php
+++ b/src/UriFactory/GuzzleUriFactory.php
@@ -9,6 +9,7 @@ use Http\Message\UriFactory;
  * Creates Guzzle URI.
  *
  * @author David de Boer <david@ddeboer.nl>
+ * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleUriFactory implements UriFactory
 {

--- a/src/UriFactory/GuzzleUriFactory.php
+++ b/src/UriFactory/GuzzleUriFactory.php
@@ -10,7 +10,7 @@ use Http\Message\UriFactory;
  *
  * @author David de Boer <david@ddeboer.nl>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleUriFactory implements UriFactory
 {

--- a/src/UriFactory/GuzzleUriFactory.php
+++ b/src/UriFactory/GuzzleUriFactory.php
@@ -9,6 +9,7 @@ use Http\Message\UriFactory;
  * Creates Guzzle URI.
  *
  * @author David de Boer <david@ddeboer.nl>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Guzzle PSR-17 factory
  */
 final class GuzzleUriFactory implements UriFactory

--- a/src/UriFactory/SlimUriFactory.php
+++ b/src/UriFactory/SlimUriFactory.php
@@ -10,6 +10,7 @@ use Slim\Http\Uri;
  * Creates Slim 3 URI.
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
+ * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimUriFactory implements UriFactory
 {

--- a/src/UriFactory/SlimUriFactory.php
+++ b/src/UriFactory/SlimUriFactory.php
@@ -10,6 +10,7 @@ use Slim\Http\Uri;
  * Creates Slim 3 URI.
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
+ *
  * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimUriFactory implements UriFactory

--- a/src/UriFactory/SlimUriFactory.php
+++ b/src/UriFactory/SlimUriFactory.php
@@ -11,7 +11,7 @@ use Slim\Http\Uri;
  *
  * @author Mika Tuupola <tuupola@appelsiini.net>
  *
- * @deprecated This will be removed in 2.0. Consider using the official Slim PSR-17 factory
+ * @deprecated This will be removed in php-http/message2.0. Consider using the official Slim PSR-17 factory
  */
 final class SlimUriFactory implements UriFactory
 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #105 
| Documentation   | 
| License         | MIT


#### What's in this PR?

PSR-17 is out. Our factories are not BC compatible with PSR-17 because of PHP7 return types. I think we should remove our factories in version 2. 

Note. I do not suggest we plan for a version 2 release. 