### PR TITLE
Fix: Drop support for unsupported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - 7.3
@@ -22,12 +18,11 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 5.4
+        - php: 7.1
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
-    - if [[ "${TRAVIS_PHP_VERSION}" == "5.4" ]]; then composer remove slim/slim --dev --no-update; fi
 
 install:
     - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0",
+        "php": "^7.1",
         "clue/stream-filter": "^1.4",
         "php-http/message-factory": "^1.0.2",
         "psr/http-message": "^1.0"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT

#### What's in this PR?

This PR

* [x] drops support for unsupported PHP versions