### PR TITLE
Fix fatal error for long bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Fatal error on `CurlCommandFormatter` when body is larger than `escapeshellarg` allowed length.   
+
 ## [1.7.2] - 2018-10-30
 
 ### Fixed

--- a/spec/Formatter/CurlCommandFormatterSpec.php
+++ b/spec/Formatter/CurlCommandFormatterSpec.php
@@ -108,4 +108,22 @@ class CurlCommandFormatterSpec extends ObjectBehavior
 
         $this->formatRequest($request)->shouldReturn("curl 'http://foo.com/bar' --request POST --data '[non-seekable stream omitted]'");
     }
+
+    function it_formats_requests_with_long_body(RequestInterface $request, UriInterface $uri, StreamInterface $body)
+    {
+        $request->getUri()->willReturn($uri);
+        $request->getBody()->willReturn($body);
+
+        $body->__toString()->willReturn('a very long body');
+        $body->getSize()->willReturn(2097153);
+        $body->isSeekable()->willReturn(true);
+        $body->rewind()->willReturn(true);
+
+        $uri->withFragment('')->willReturn('http://foo.com/bar');
+        $request->getMethod()->willReturn('POST');
+        $request->getProtocolVersion()->willReturn('1.1');
+        $request->getHeaders()->willReturn([]);
+
+        $this->formatRequest($request)->shouldReturn("curl 'http://foo.com/bar' --request POST --data '[too long stream omitted]'");
+    }
 }

--- a/src/Formatter/CurlCommandFormatter.php
+++ b/src/Formatter/CurlCommandFormatter.php
@@ -36,7 +36,7 @@ class CurlCommandFormatter implements Formatter
 
         $body = $request->getBody();
         if ($body->getSize() > 0) {
-            // escapeshellarg argument max length on Windows, but impractical to use either way
+            // escapeshellarg argument max length on Windows, but longer body in curl command would be impractical anyways
             if ($body->getSize() > 8192) {
                 $data = '[too long stream omitted]';
             } elseif ($body->isSeekable()) {

--- a/src/Formatter/CurlCommandFormatter.php
+++ b/src/Formatter/CurlCommandFormatter.php
@@ -36,10 +36,8 @@ class CurlCommandFormatter implements Formatter
 
         $body = $request->getBody();
         if ($body->getSize() > 0) {
-            // escapeshellarg argument max length
-            $argMaxLength = '\\' === DIRECTORY_SEPARATOR ? 8192 : 2097152;
-
-            if ($body->getSize() > $argMaxLength) {
+            // escapeshellarg argument max length on Windows, but impractical to use either way
+            if ($body->getSize() > 8192) {
                 $data = '[too long stream omitted]';
             } elseif ($body->isSeekable()) {
                 $data = $body->__toString();

--- a/src/Formatter/CurlCommandFormatter.php
+++ b/src/Formatter/CurlCommandFormatter.php
@@ -36,7 +36,12 @@ class CurlCommandFormatter implements Formatter
 
         $body = $request->getBody();
         if ($body->getSize() > 0) {
-            if ($body->isSeekable()) {
+            // escapeshellarg argument max length
+            $argMaxLength = '\\' === DIRECTORY_SEPARATOR ? 8192 : 2097152;
+
+            if ($body->getSize() > $argMaxLength) {
+                $data = '[too long stream omitted]';
+            } elseif ($body->isSeekable()) {
                 $data = $body->__toString();
                 $body->rewind();
                 if (preg_match('/[\x00-\x1F\x7F]/', $data)) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #93 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Prevent `CurlCommandFormatter` to throw a Fatal exception when body size exceed `escapeshellarg` argument allowed length. Didn't find a great way to get the limit tho... Windows limit come from [PHP source code](https://github.com/php/php-src/blob/959091285487878790f2f2fe71301954f3c765a9/ext/standard/exec.c#L62-L80), the UNIX from 
```
echo $(getconf ARG_MAX)
```
If you have a better solution to find `escapeshellarg` limit, I'm all ears

#### Checklist

- [x] Updated CHANGELOG.md to describe bugfix