### PR TITLE
add Header authentication method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- New Header authentication method for arbitrary header authentication.
+
 ## [1.8.0] - 2019-08-05
 
 ### Changed

--- a/spec/Authentication/HeaderSpec.php
+++ b/spec/Authentication/HeaderSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace spec\Http\Message\Authentication;
+
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+
+class HeaderSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('X-AUTH-TOKEN', 'REAL');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Message\Authentication\Header');
+    }
+
+    function it_is_an_authentication()
+    {
+        $this->shouldImplement('Http\Message\Authentication');
+    }
+
+    function it_authenticates_a_request(RequestInterface $request, RequestInterface $newRequest)
+    {
+        $request->withHeader('X-AUTH-TOKEN', 'REAL')->willReturn($newRequest);
+
+        $this->authenticate($request)->shouldReturn($newRequest);
+    }
+}

--- a/src/Authentication/Header.php
+++ b/src/Authentication/Header.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Http\Message\Authentication;
+
+use Http\Message\Authentication;
+use Psr\Http\Message\RequestInterface;
+
+class Header implements Authentication
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string|array
+     */
+    private $value;
+
+    public function __construct(string $name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function authenticate(RequestInterface $request)
+    {
+        return $request->withHeader($this->name, $this->value);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | https://github.com/php-http/documentation/pull/270
| License         | MIT

#### What's in this PR?

This add a Header authentication method for arbitrary header based authentication (like X-AUTH-TOKEN).


#### Example Usage

```php
new AuthenticationPlugin(new Header('X-AUTH-TOKEN', 'REAL'));
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
