### PR TITLE
Enhancement: Use ergebnis/composer-normalize instead of localheinz/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
         "ext-zlib": "*",
         "akeneo/phpspec-skip-example-extension": "^1.0",
         "coduo/phpspec-data-provider-extension": "^1.0",
+        "ergebnis/composer-normalize": "^2.1.1",
         "guzzlehttp/psr7": "^1.0",
         "henrikbjorn/phpspec-code-coverage": "^1.0",
-        "localheinz/composer-normalize": "^1.2.0",
         "phpspec/phpspec": "^2.4",
         "slim/slim": "^3.0",
         "zendframework/zend-diactoros": "^1.0"


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/composer-normalize` instead of `localheinz/composer-normalize`

Related to https://github.com/ergebnis/composer-normalize/issues/266.

💁‍♂ For reference, see https://localheinz.com/blog/2019/12/10/from-localheinz-to-ergebnis/.