### PR TITLE
Fix: composer.json -  clue/stream-filter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "clue/stream-filter": "^1.4",
+        "clue/stream-filter": "^1.4.1",
         "php-http/message-factory": "^1.0.2",
         "psr/http-message": "^1.0"
     },


### PR DESCRIPTION
>  clue/stream-filter version should update to 1.4.1. 

**Problem:**  if you use "php-http/message" several time in a package, it will call "clue/stream-filter" several time. On their previous version, before 1.4.1, they didn't have the duplicate function checking. So, it will create same namespace several time. 

**Real Life Example:**  "php-http/message" has been used in - [infusionsoft/php-sdk](https://github.com/infusionsoft/infusionsoft-php)
if you create several wordpress plugins with - infusionsoft/php-sdk and install all the plugins in same website then "php-http/message" will be called several time so the "clue/stream-filter". Which create error for using same namespace.
