### PR TITLE
Omit binary body in FullHttpMessageFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Omitted binary body in FullHttpMessageFormatter. `[binary stream omitted]` will be shown instead.
+
 ### Added
 
 - New Header authentication method for arbitrary header authentication.

--- a/spec/Formatter/FullHttpMessageFormatterSpec.php
+++ b/spec/Formatter/FullHttpMessageFormatterSpec.php
@@ -227,4 +227,25 @@ X-Param-Bar: bar
 STR;
         $this->formatResponse($response)->shouldReturn($expectedMessage);
     }
+
+    function it_omits_body_with_null_bytes(RequestInterface $request, StreamInterface $stream)
+    {
+        $this->beConstructedWith(1);
+
+        $stream->isSeekable()->willReturn(true);
+        $stream->rewind()->shouldBeCalled();
+        $stream->__toString()->willReturn("\0");
+        $request->getBody()->willReturn($stream);
+        $request->getMethod()->willReturn('GET');
+        $request->getRequestTarget()->willReturn('/foo');
+        $request->getProtocolVersion()->willReturn('1.1');
+        $request->getHeaders()->willReturn([]);
+
+        $expectedMessage = <<<STR
+GET /foo HTTP/1.1
+
+[binary stream omitted]
+STR;
+        $this->formatRequest($request)->shouldReturn($expectedMessage);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #126
| Documentation   | -
| License         | MIT


#### What's in this PR?

Makes handling for binary body similar to what CurlCommandFormatter does. I was initially playing with idea to use bin2hex, but then I realized people who actually want binary bodies logged will be minority, for majority this is something they are logging unintended by oversight.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)