### PR TITLE
migrated to laminas/laminas-diactoros (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Migrated from `zendframework/zend-diactoros` to `laminas/laminas-diactoros`.
+   Users are encouraged to update their dependencies by simply replacing the Zend package with the Laminas package.
+   Due to the [laminas-zendframework-brige](https://github.com/laminas/laminas-zendframework-bridge), BC changes
+   are not expected and legacy code does not need to be refactored (though it is
+   [recommended and simple](https://docs.laminas.dev/migration/)).
+- The diactoros factories of `php-http/message` will return objects from the `Laminas\Diactoros\` namespace, if
+   the respective classes are available via autoloading, but continue to return objects from `Zend\Diactoros\`
+   namespace otherwise.
+
 ## [1.10.0] - 2020-11-11
 
 - Added support for PHP 8.0.

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
         "guzzlehttp/psr7": "^1.0",
         "phpspec/phpspec": "^5.1 || ^6.3",
         "slim/slim": "^3.0",
-        "zendframework/zend-diactoros": "^1.0"
+        "laminas/laminas-diactoros": "^2.0"
     },
     "suggest": {
         "ext-zlib": "Used with compressor/decompressor streams",
         "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
-        "slim/slim": "Used with Slim Framework PSR-7 implementation",
-        "zendframework/zend-diactoros": "Used with Diactoros Factories"
+        "laminas/laminas-diactoros": "Used with Diactoros Factories",
+        "slim/slim": "Used with Slim Framework PSR-7 implementation"
     },
     "config": {
         "sort-packages": true

--- a/puli.json
+++ b/puli.json
@@ -7,7 +7,7 @@
             "class": "Http\\Message\\MessageFactory\\DiactorosMessageFactory",
             "type": "Http\\Message\\MessageFactory",
             "parameters": {
-                "depends": "Zend\\Diactoros\\Request"
+                "depends": "Laminas\\Diactoros\\Request"
             }
         },
         "0836751e-6558-4d1b-8993-4a52012947c3": {
@@ -57,7 +57,7 @@
             "class": "Http\\Message\\UriFactory\\DiactorosUriFactory",
             "type": "Http\\Message\\UriFactory",
             "parameters": {
-                "depends": "Zend\\Diactoros\\Uri"
+                "depends": "Laminas\\Diactoros\\Uri"
             }
         },
         "4672a6ee-ad9e-4109-a5d1-b7d46f26c7a1": {
@@ -70,7 +70,7 @@
             "class": "Http\\Message\\MessageFactory\\DiactorosMessageFactory",
             "type": "Http\\Message\\ResponseFactory",
             "parameters": {
-                "depends": "Zend\\Diactoros\\Response"
+                "depends": "Laminas\\Diactoros\\Response"
             }
         },
         "6a9ad6ce-d82c-470f-8e30-60f21d9d95bf": {
@@ -88,7 +88,7 @@
             "class": "Http\\Message\\StreamFactory\\DiactorosStreamFactory",
             "type": "Http\\Message\\StreamFactory",
             "parameters": {
-                "depends": "Zend\\Diactoros\\Stream"
+                "depends": "Laminas\\Diactoros\\Stream"
             }
         },
         "a018af27-7590-4dcf-83a1-497f95604cd6": {
@@ -104,7 +104,7 @@
             "class": "Http\\Message\\MessageFactory\\DiactorosMessageFactory",
             "type": "Http\\Message\\RequestFactory",
             "parameters": {
-                "depends": "Zend\\Diactoros\\Request"
+                "depends": "Laminas\\Diactoros\\Request"
             }
         }
     }

--- a/puli.json
+++ b/puli.json
@@ -7,7 +7,7 @@
             "class": "Http\\Message\\MessageFactory\\DiactorosMessageFactory",
             "type": "Http\\Message\\MessageFactory",
             "parameters": {
-                "depends": "Laminas\\Diactoros\\Request"
+                "depends": "Zend\\Diactoros\\Request"
             }
         },
         "0836751e-6558-4d1b-8993-4a52012947c3": {
@@ -57,7 +57,7 @@
             "class": "Http\\Message\\UriFactory\\DiactorosUriFactory",
             "type": "Http\\Message\\UriFactory",
             "parameters": {
-                "depends": "Laminas\\Diactoros\\Uri"
+                "depends": "Zend\\Diactoros\\Uri"
             }
         },
         "4672a6ee-ad9e-4109-a5d1-b7d46f26c7a1": {
@@ -70,7 +70,7 @@
             "class": "Http\\Message\\MessageFactory\\DiactorosMessageFactory",
             "type": "Http\\Message\\ResponseFactory",
             "parameters": {
-                "depends": "Laminas\\Diactoros\\Response"
+                "depends": "Zend\\Diactoros\\Response"
             }
         },
         "6a9ad6ce-d82c-470f-8e30-60f21d9d95bf": {
@@ -88,7 +88,7 @@
             "class": "Http\\Message\\StreamFactory\\DiactorosStreamFactory",
             "type": "Http\\Message\\StreamFactory",
             "parameters": {
-                "depends": "Laminas\\Diactoros\\Stream"
+                "depends": "Zend\\Diactoros\\Stream"
             }
         },
         "a018af27-7590-4dcf-83a1-497f95604cd6": {
@@ -104,7 +104,7 @@
             "class": "Http\\Message\\MessageFactory\\DiactorosMessageFactory",
             "type": "Http\\Message\\RequestFactory",
             "parameters": {
-                "depends": "Laminas\\Diactoros\\Request"
+                "depends": "Zend\\Diactoros\\Request"
             }
         }
     }

--- a/spec/StreamFactory/DiactorosStreamFactorySpec.php
+++ b/spec/StreamFactory/DiactorosStreamFactorySpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\Http\Message\StreamFactory;
 
-use Zend\Diactoros\Stream;
+use Laminas\Diactoros\Stream;
 use PhpSpec\ObjectBehavior;
 
 class DiactorosStreamFactorySpec extends ObjectBehavior

--- a/src/MessageFactory/DiactorosMessageFactory.php
+++ b/src/MessageFactory/DiactorosMessageFactory.php
@@ -4,8 +4,10 @@ namespace Http\Message\MessageFactory;
 
 use Http\Message\MessageFactory;
 use Http\Message\StreamFactory\DiactorosStreamFactory;
-use Laminas\Diactoros\Request;
-use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Request as LaminasRequest;
+use Laminas\Diactoros\Response as LaminasResponse;
+use Zend\Diactoros\Request as ZendRequest;
+use Zend\Diactoros\Response as ZendResponse;
 
 /**
  * Creates Diactoros messages.
@@ -36,7 +38,16 @@ final class DiactorosMessageFactory implements MessageFactory
         $body = null,
         $protocolVersion = '1.1'
     ) {
-        return (new Request(
+        if (class_exists(LaminasRequest::class)) {
+            return (new LaminasRequest(
+                $uri,
+                $method,
+                $this->streamFactory->createStream($body),
+                $headers
+            ))->withProtocolVersion($protocolVersion);
+        }
+
+        return (new ZendRequest(
             $uri,
             $method,
             $this->streamFactory->createStream($body),
@@ -54,7 +65,15 @@ final class DiactorosMessageFactory implements MessageFactory
         $body = null,
         $protocolVersion = '1.1'
     ) {
-        return (new Response(
+        if (class_exists(LaminasResponse::class)) {
+            return (new LaminasResponse(
+                $this->streamFactory->createStream($body),
+                $statusCode,
+                $headers
+            ))->withProtocolVersion($protocolVersion);
+        }
+
+        return (new ZendResponse(
             $this->streamFactory->createStream($body),
             $statusCode,
             $headers

--- a/src/MessageFactory/DiactorosMessageFactory.php
+++ b/src/MessageFactory/DiactorosMessageFactory.php
@@ -4,8 +4,8 @@ namespace Http\Message\MessageFactory;
 
 use Http\Message\MessageFactory;
 use Http\Message\StreamFactory\DiactorosStreamFactory;
-use Zend\Diactoros\Request;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Response;
 
 /**
  * Creates Diactoros messages.

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -3,8 +3,9 @@
 namespace Http\Message\StreamFactory;
 
 use Http\Message\StreamFactory;
-use Laminas\Diactoros\Stream;
+use Laminas\Diactoros\Stream as LaminasStream;
 use Psr\Http\Message\StreamInterface;
+use Zend\Diactoros\Stream as ZendStream;
 
 /**
  * Creates Diactoros streams.
@@ -25,10 +26,19 @@ final class DiactorosStreamFactory implements StreamFactory
         }
 
         if (is_resource($body)) {
-            return new Stream($body);
+            if (class_exists(LaminasStream::class)) {
+                return new LaminasStream($body);
+            }
+
+            return new ZendStream($body);
         }
 
-        $stream = new Stream('php://memory', 'rw');
+        if (class_exists(LaminasStream::class)) {
+            $stream = new LaminasStream('php://memory', 'rw');
+        } else {
+            $stream = new ZendStream('php://memory', 'rw');
+        }
+
         if (null !== $body && '' !== $body) {
             $stream->write((string) $body);
         }

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -3,8 +3,8 @@
 namespace Http\Message\StreamFactory;
 
 use Http\Message\StreamFactory;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\StreamInterface;
-use Zend\Diactoros\Stream;
 
 /**
  * Creates Diactoros streams.

--- a/src/UriFactory/DiactorosUriFactory.php
+++ b/src/UriFactory/DiactorosUriFactory.php
@@ -3,8 +3,9 @@
 namespace Http\Message\UriFactory;
 
 use Http\Message\UriFactory;
-use Laminas\Diactoros\Uri;
+use Laminas\Diactoros\Uri as LaminasUri;
 use Psr\Http\Message\UriInterface;
+use Zend\Diactoros\Uri as ZendUri;
 
 /**
  * Creates Diactoros URI.
@@ -23,7 +24,11 @@ final class DiactorosUriFactory implements UriFactory
         if ($uri instanceof UriInterface) {
             return $uri;
         } elseif (is_string($uri)) {
-            return new Uri($uri);
+            if (class_exists(LaminasUri::class)) {
+                return new LaminasUri($uri);
+            }
+
+            return new ZendUri($uri);
         }
 
         throw new \InvalidArgumentException('URI must be a string or UriInterface');

--- a/src/UriFactory/DiactorosUriFactory.php
+++ b/src/UriFactory/DiactorosUriFactory.php
@@ -3,8 +3,8 @@
 namespace Http\Message\UriFactory;
 
 use Http\Message\UriFactory;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Message\UriInterface;
-use Zend\Diactoros\Uri;
 
 /**
  * Creates Diactoros URI.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #125 
| License         | MIT


#### What's in this PR?

This PR replaces zend/zend-diactoros with laminas/laminas-diactoros. Due to laminas/laminas-zendframework-bridge, there is no BC break.


#### Why?

Because zend/zend-diactoros is officially abandoned.
