### PR TITLE
Resolves issue #43

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,6 +6,7 @@ $config = PhpCsFixer\Config::create()
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
         'single_line_throw' => false,
+        'protected_to_private' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,7 +6,6 @@ $config = PhpCsFixer\Config::create()
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
         'single_line_throw' => false,
-        'protected_to_private' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    the respective classes are available via autoloading, but continue to return objects from `Zend\Diactoros\`
    namespace otherwise.
 
+## [1.11.0] - unreleased
+
+- Allow to specify the hashing algorithm for WSSE authentication.
+
 ## [1.10.0] - 2020-11-11
 
 - Added support for PHP 8.0.

--- a/src/Authentication/Wsse.php
+++ b/src/Authentication/Wsse.php
@@ -29,11 +29,6 @@ final class Wsse implements Authentication
     private $hashAlgorithm;
 
     /**
-     * @var array<string>
-     */
-    private $acceptedHashAlgos = ['sha1', 'sha512', 'sha384', 'sha3-384', 'sha3-512'];
-
-    /**
      * @param string $username
      * @param string $password
      * @param string $hashAlgorithm To use a better hashing algorithm than the weak sha1, pass the algorithm to use, e.g. "sha512"
@@ -42,6 +37,9 @@ final class Wsse implements Authentication
     {
         $this->username = $username;
         $this->password = $password;
+        if (false === in_array($hashAlgorithm, hash_algos())) {
+            throw new InvalidArgumentException(sprintf('Unaccepted hashing algorithm: %s', $hashAlgorithm));
+        }
         $this->hashAlgorithm = $hashAlgorithm;
     }
 
@@ -52,9 +50,6 @@ final class Wsse implements Authentication
     {
         $nonce = substr(md5(uniqid(uniqid().'_', true)), 0, 16);
         $created = date('c');
-        if (false === in_array($this->hashAlgorithm, $this->acceptedHashAlgos)) {
-            throw new InvalidArgumentException(sprintf('Unaccepted hashing algorithm: %s', $this->hashAlgorithm));
-        }
         $digest = base64_encode(hash($this->hashAlgorithm, base64_decode($nonce).$created.$this->password, true));
 
         $wsse = sprintf(

--- a/src/Authentication/Wsse.php
+++ b/src/Authentication/Wsse.php
@@ -3,6 +3,7 @@
 namespace Http\Message\Authentication;
 
 use Http\Message\Authentication;
+use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -23,13 +24,25 @@ final class Wsse implements Authentication
     private $password;
 
     /**
+     * @var string
+     */
+    private $hashAlgorithm;
+
+    /**
+     * @var array<string>
+     */
+    private $acceptedHashAlgos = ['sha1', 'sha512', 'sha384', 'sha3-384', 'sha3-512'];
+
+    /**
      * @param string $username
      * @param string $password
+     * @param string $hashAlgorithm To use a better hashing algorithm than the weak sha1, pass the algorithm to use, e.g. "sha512"
      */
-    public function __construct($username, $password)
+    public function __construct($username, $password, $hashAlgorithm = 'sha1')
     {
         $this->username = $username;
         $this->password = $password;
+        $this->hashAlgorithm = $hashAlgorithm;
     }
 
     /**
@@ -37,10 +50,12 @@ final class Wsse implements Authentication
      */
     public function authenticate(RequestInterface $request)
     {
-        // TODO: generate better nonce?
         $nonce = substr(md5(uniqid(uniqid().'_', true)), 0, 16);
         $created = date('c');
-        $digest = base64_encode(sha1(base64_decode($nonce).$created.$this->password, true));
+        if (false === in_array($this->hashAlgorithm, $this->acceptedHashAlgos)) {
+            throw new InvalidArgumentException(sprintf('Unaccepted hashing algorithm: %s', $this->hashAlgorithm));
+        }
+        $digest = base64_encode(hash($this->hashAlgorithm, base64_decode($nonce).$created.$this->password, true));
 
         $wsse = sprintf(
             'UsernameToken Username="%s", PasswordDigest="%s", Nonce="%s", Created="%s"',

--- a/src/CookieJar.php
+++ b/src/CookieJar.php
@@ -10,7 +10,7 @@ namespace Http\Message;
 final class CookieJar implements \Countable, \IteratorAggregate
 {
     /**
-     * @var \SplObjectStorage
+     * @var \SplObjectStorage<object, mixed>
      */
     protected $cookies;
 

--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -13,12 +13,11 @@ use Psr\Http\Message\StreamInterface;
  */
 abstract class FilteredStream implements StreamInterface
 {
-    const BUFFER_SIZE = 8192;
-
     use StreamDecorator {
         rewind as private doRewind;
         seek as private doSeek;
     }
+    const BUFFER_SIZE = 8192;
 
     /**
      * @var callable


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | issue #43
| Documentation   | N/A
| License         | MIT

Closes #43.

#### What's in this PR?

- Using the `hash('sha512')` to replace `sha1` function.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)