### PR TITLE
support guzzle psr7 version 2

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHP-CS-Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga
+        uses: docker://oskarstark/php-cs-fixer-ga:2.19.0
         with:
           args: --dry-run --diff-format udiff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2021-05-24
+
+- Support GuzzleHttp/Psr7 version 2.0 in the (deprecated) GuzzleUriFactory.
+
 ## [1.11.0] - 2020-02-01
 
 - Migrated from `zendframework/zend-diactoros` to `laminas/laminas-diactoros`.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,17 +11,17 @@ parameters:
 			path: src/Authentication/Header.php
 
 		-
+			message: "#The Http\\\\Message\\\\Authentication\\\\Matching class is deprecated since version 1.2 and will be removed in 2.0.#"
+			count: 1
+			path: src/Authentication/Matching.php
+
+		-
 			message: "#^Property Http\\\\Message\\\\Authentication\\\\QueryParam\\:\\:\\$params type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Authentication/QueryParam.php
 
 		-
 			message: "#^Method Http\\\\Message\\\\Authentication\\\\QueryParam\\:\\:__construct\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Authentication/QueryParam.php
-
-		-
-			message: "#^Parameter \\#2 \\$prefix of function http_build_query expects string, null given\\.$#"
 			count: 1
 			path: src/Authentication/QueryParam.php
 
@@ -46,7 +46,7 @@ parameters:
 			path: src/Cookie.php
 
 		-
-			message: "#^Parameter \\#2 \\$str2 of function strcasecmp expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#2 \\$string2 of function strcasecmp expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Cookie.php
 
@@ -76,7 +76,7 @@ parameters:
 			path: src/Cookie.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function rtrim expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function rtrim expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Cookie.php
 
@@ -161,16 +161,6 @@ parameters:
 			path: src/Encoding/Filter/Chunk.php
 
 		-
-			message: "#^Parameter \\#2 \\$bucket of function stream_bucket_append expects object, resource given\\.$#"
-			count: 2
-			path: src/Encoding/Filter/Chunk.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: src/Encoding/Filter/Chunk.php
-
-		-
 			message: "#^Method Http\\\\Message\\\\Encoding\\\\FilteredStream\\:\\:fill\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Encoding/FilteredStream.php
@@ -214,6 +204,11 @@ parameters:
 			message: "#^Method Http\\\\Message\\\\MessageFactory\\\\SlimMessageFactory\\:\\:createResponse\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/MessageFactory/SlimMessageFactory.php
+
+		-
+			message: "#The Http\\\\Message\\\\RequestMatcher\\\\RegexRequestMatcher class is deprecated since version 1.2 and will be removed in 2.0.#"
+			count: 1
+			path: src/RequestMatcher/RegexRequestMatcher.php
 
 		-
 			message: "#^Property Http\\\\Message\\\\RequestMatcher\\\\RequestMatcher\\:\\:\\$methods type has no value type specified in iterable type array\\.$#"

--- a/src/Authentication/QueryParam.php
+++ b/src/Authentication/QueryParam.php
@@ -38,7 +38,7 @@ final class QueryParam implements Authentication
 
         $params = array_merge($params, $this->params);
 
-        $query = http_build_query($params, null, '&');
+        $query = http_build_query($params, '', '&');
 
         $uri = $uri->withQuery($query);
 

--- a/src/UriFactory/GuzzleUriFactory.php
+++ b/src/UriFactory/GuzzleUriFactory.php
@@ -2,7 +2,8 @@
 
 namespace Http\Message\UriFactory;
 
-use GuzzleHttp\Psr7;
+use function GuzzleHttp\Psr7\uri_for;
+use GuzzleHttp\Psr7\Utils;
 use Http\Message\UriFactory;
 
 /**
@@ -19,6 +20,10 @@ final class GuzzleUriFactory implements UriFactory
      */
     public function createUri($uri)
     {
-        return Psr7\uri_for($uri);
+        if (class_exists(Utils::class)) {
+            return Utils::uriFor($uri);
+        }
+
+        return uri_for($uri);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #138
| License         | MIT


#### What's in this PR?

Support guzzle psr7 version 2 that moved functions to static methods of the Utils class. Our factory is deprecated but still used when no other factory is available, and as we don't restrict the guzzle psr version, we end up failing.