### PR TITLE
GuzzleStreamFactory: support guzzle/psr7 version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.11.2] - 2021-XX-XX
+
+- Support GuzzleHttp/Psr7 version 2.0 in the (deprecated) GuzzleStreamFactory.
+
 ## [1.11.1] - 2021-05-24
 
 - Support GuzzleHttp/Psr7 version 2.0 in the (deprecated) GuzzleUriFactory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.11.2] - 2021-XX-XX
+## [1.11.2] - 2021-08-03
 
 - Support GuzzleHttp/Psr7 version 2.0 in the (deprecated) GuzzleStreamFactory.
 

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -2,8 +2,8 @@
 
 namespace Http\Message\StreamFactory;
 
-use Http\Message\StreamFactory;
 use GuzzleHttp\Psr7\Utils;
+use Http\Message\StreamFactory;
 
 /**
  * Creates Guzzle streams.

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -3,7 +3,6 @@
 namespace Http\Message\StreamFactory;
 
 use Http\Message\StreamFactory;
-use function GuzzleHttp\Psr7\uri_for;
 use GuzzleHttp\Psr7\Utils;
 
 /**

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -3,6 +3,8 @@
 namespace Http\Message\StreamFactory;
 
 use Http\Message\StreamFactory;
+use function GuzzleHttp\Psr7\uri_for;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * Creates Guzzle streams.
@@ -18,6 +20,10 @@ final class GuzzleStreamFactory implements StreamFactory
      */
     public function createStream($body = null)
     {
+        if (class_exists(Utils::class)) {
+            return Utils::streamFor($body);
+        }
+
         return \GuzzleHttp\Psr7\stream_for($body);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/php-http/message/issues/140
| Documentation   | no
| License         | MIT


fixed `GuzzleStreamFactory` compat with guzzle/psr7 version 2 similat to https://github.com/php-http/message/pull/139 which fixed it for `GuzzleUriFactory`