### PR TITLE
Add support for adjusting binary detection regex in FullHttpMessageFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - ?
+
+- Added support for adjusting binary detection regex in FullHttpMessageFormatter
+
 ## [1.11.2] - 2021-08-03
 
 - Support GuzzleHttp/Psr7 version 2.0 in the (deprecated) GuzzleStreamFactory.

--- a/spec/Formatter/FullHttpMessageFormatterSpec.php
+++ b/spec/Formatter/FullHttpMessageFormatterSpec.php
@@ -249,6 +249,27 @@ STR;
         $this->formatRequest($request)->shouldReturn($expectedMessage);
     }
 
+    function it_allows_to_change_binary_detection(RequestInterface $request, StreamInterface $stream)
+    {
+        $this->beConstructedWith(1, '/\x01/');
+
+        $stream->isSeekable()->willReturn(true);
+        $stream->rewind()->shouldBeCalled();
+        $stream->__toString()->willReturn("\0");
+        $request->getBody()->willReturn($stream);
+        $request->getMethod()->willReturn('GET');
+        $request->getRequestTarget()->willReturn('/foo');
+        $request->getProtocolVersion()->willReturn('1.1');
+        $request->getHeaders()->willReturn([]);
+
+        $expectedMessage = <<<STR
+GET /foo HTTP/1.1
+
+\x0
+STR;
+        $this->formatRequest($request)->shouldReturn($expectedMessage);
+    }
+
     function it_omits_body_with_line_break(RequestInterface $request, StreamInterface $stream)
     {
         $this->beConstructedWith(7);

--- a/src/Formatter/FullHttpMessageFormatter.php
+++ b/src/Formatter/FullHttpMessageFormatter.php
@@ -22,11 +22,18 @@ class FullHttpMessageFormatter implements Formatter
     private $maxBodyLength;
 
     /**
-     * @param int|null $maxBodyLength
+     * @var string
      */
-    public function __construct($maxBodyLength = 1000)
+    private $binaryDetectionRegex;
+
+    /**
+     * @param int|null $maxBodyLength
+     * @param string   $binaryDetectionRegex By default, this is all non-printable ASCII characters and <DEL> except for \t, \r, \n
+     */
+    public function __construct($maxBodyLength = 1000, string $binaryDetectionRegex = '/([\x00-\x09\x0C\x0E-\x1F\x7F])/')
     {
         $this->maxBodyLength = $maxBodyLength;
+        $this->binaryDetectionRegex = $binaryDetectionRegex;
     }
 
     /**
@@ -86,8 +93,7 @@ class FullHttpMessageFormatter implements Formatter
         $data = $stream->__toString();
         $stream->rewind();
 
-        // all non-printable ASCII characters and <DEL> except for \t, \r, \n
-        if (preg_match('/([\x00-\x09\x0C\x0E-\x1F\x7F])/', $data)) {
+        if (preg_match($this->binaryDetectionRegex, $data)) {
             return $message.'[binary stream omitted]';
         }
 


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


Regrettably, in our applications, php serialize() is often used instead of JSON as a serialization format used over wire. Instead of changing default regex for everyone (which could be a security risk in case target endpoint is untrusted), this allows to inject custom regex.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
