### PR TITLE
Add Formatter::formatResponseForRequest()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - tomorrow
+
+- Added `Formatter::formatResponseForRequest()`
+
 ## [1.12.0] - 2021-08-29
 
 - Added support for adjusting binary detection regex in FullHttpMessageFormatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.13.0] - tomorrow
 
 - Added `Formatter::formatResponseForRequest()`
+- Deprecated `Formatter::formatResponse()`
 
 ## [1.12.0] - 2021-08-29
 

--- a/spec/Formatter/CurlCommandFormatterSpec.php
+++ b/spec/Formatter/CurlCommandFormatterSpec.php
@@ -54,9 +54,10 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $this->formatRequest($request)->shouldReturn("curl 'http://foo.com/bar' --http2 --request POST --data 'body \" data test'\'' bar'");
     }
 
-    function it_does_nothing_for_response(ResponseInterface $response)
+    function it_does_nothing_for_response(ResponseInterface $response, RequestInterface $request)
     {
         $this->formatResponse($response)->shouldReturn('');
+        $this->formatResponseForRequest($response, $request)->shouldReturn('');
     }
 
     function it_formats_the_request_with_user_agent(RequestInterface $request, UriInterface $uri, StreamInterface $body)

--- a/spec/Formatter/FullHttpMessageFormatterSpec.php
+++ b/spec/Formatter/FullHttpMessageFormatterSpec.php
@@ -126,7 +126,7 @@ STR;
         $this->formatRequest($request)->shouldReturn($expectedMessage);
     }
 
-    function it_formats_the_response_with_size_limit(ResponseInterface $response, StreamInterface $stream)
+    function it_formats_the_response_with_size_limit(ResponseInterface $response, StreamInterface $stream, RequestInterface $request)
     {
         $this->beConstructedWith(18);
 
@@ -150,6 +150,7 @@ X-Param-Bar: bar
 This is an HTML st
 STR;
         $this->formatResponse($response)->shouldReturn($expectedMessage);
+        $this->formatResponseForRequest($response, $request)->shouldReturn($expectedMessage);
     }
 
     function it_formats_the_response_without_size_limit(ResponseInterface $response, StreamInterface $stream)

--- a/spec/Formatter/SimpleFormatterSpec.php
+++ b/spec/Formatter/SimpleFormatterSpec.php
@@ -29,12 +29,13 @@ class SimpleFormatterSpec extends ObjectBehavior
         $this->formatRequest($request)->shouldReturn('GET http://foo.com/bar 1.1');
     }
 
-    function it_formats_the_response(ResponseInterface $response)
+    function it_formats_the_response(ResponseInterface $response, RequestInterface $request)
     {
         $response->getReasonPhrase()->willReturn('OK');
         $response->getProtocolVersion()->willReturn('1.1');
         $response->getStatusCode()->willReturn('200');
 
         $this->formatResponse($response)->shouldReturn('200 OK 1.1');
+        $this->formatResponseForRequest($response, $request)->shouldReturn('200 OK 1.1');
     }
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
  * Formats a request and/or a response as a string.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
- * 
+ *
  * @method string formatResponseForRequest(ResponseInterface $response, RequestInterface $request) Formats a response in context of its request.
  */
 interface Formatter
@@ -22,6 +22,8 @@ interface Formatter
     public function formatRequest(RequestInterface $request);
 
     /**
+     * @deprecated since 1.13, use formatResponseForRequest() instead
+     *
      * Formats a response.
      *
      * @return string

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\ResponseInterface;
  * Formats a request and/or a response as a string.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ * 
+ * @method string formatResponseForRequest(ResponseInterface $response, RequestInterface $request) Formats a response in context of its request.
  */
 interface Formatter
 {

--- a/src/Formatter/CurlCommandFormatter.php
+++ b/src/Formatter/CurlCommandFormatter.php
@@ -69,6 +69,14 @@ class CurlCommandFormatter implements Formatter
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function formatResponseForRequest(ResponseInterface $response, RequestInterface $request)
+    {
+        return $this->formatResponse($response);
+    }
+
+    /**
      * @return string
      */
     private function getHeadersAsCommandOptions(RequestInterface $request)

--- a/src/Formatter/FullHttpMessageFormatter.php
+++ b/src/Formatter/FullHttpMessageFormatter.php
@@ -75,6 +75,14 @@ class FullHttpMessageFormatter implements Formatter
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function formatResponseForRequest(ResponseInterface $response, RequestInterface $request)
+    {
+        return $this->formatResponse($response);
+    }
+
+    /**
      * Add the message body if the stream is seekable.
      *
      * @param string $message

--- a/src/Formatter/SimpleFormatter.php
+++ b/src/Formatter/SimpleFormatter.php
@@ -39,4 +39,12 @@ class SimpleFormatter implements Formatter
             $response->getProtocolVersion()
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function formatResponseForRequest(ResponseInterface $response, RequestInterface $request)
+    {
+        return $this->formatResponse($response);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no|
| New feature?    | yes
| BC breaks?      | no|
| Deprecations?   | yes |
| Related tickets | fixes #145
| Documentation   | -
| License         | MIT

During 1.x lifecycle:

```
deprecation.INFO: User Deprecated: Class "Http\HttplugBundle\Collector\Formatter" should implement method "Http\Message\Formatter::formatResponseForRequest(ResponseInterface $response, RequestInterface $request): string": Formats a response in context of its request.
```

Next major release should add the method for real.