### PR TITLE
Remove direct dependency on php-http/message-factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2023-XX-XX
+
+- Remove direct dependency on php-http/message-factory
+
 ## [1.15.0] - 2023-05-10
 
 **If you use the decorator classes, you might need to adjust your code to the parameter and return type declarations added in PSR-7**

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "clue/stream-filter": "^1.5",
-        "php-http/message-factory": "^1.0.2",
         "psr/http-message": "^1.1 || ^2.0"
     },
     "provide": {
@@ -27,6 +26,7 @@
         "ext-zlib": "*",
         "ergebnis/composer-normalize": "^2.6",
         "guzzlehttp/psr7": "^1.0 || ^2.0",
+        "php-http/message-factory": "^1.0.2",
         "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
         "slim/slim": "^3.0",
         "laminas/laminas-diactoros": "^2.0 || ^3.0"

--- a/src/MessageFactory/DiactorosMessageFactory.php
+++ b/src/MessageFactory/DiactorosMessageFactory.php
@@ -9,6 +9,10 @@ use Laminas\Diactoros\Response as LaminasResponse;
 use Zend\Diactoros\Request as ZendRequest;
 use Zend\Diactoros\Response as ZendResponse;
 
+if (!interface_exists(MessageFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\DiactorosMessageFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Diactoros messages.
  *

--- a/src/MessageFactory/GuzzleMessageFactory.php
+++ b/src/MessageFactory/GuzzleMessageFactory.php
@@ -6,6 +6,10 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Http\Message\MessageFactory;
 
+if (!interface_exists(MessageFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\GuzzleMessageFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Guzzle messages.
  *

--- a/src/MessageFactory/SlimMessageFactory.php
+++ b/src/MessageFactory/SlimMessageFactory.php
@@ -9,6 +9,10 @@ use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
+if (!interface_exists(MessageFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\SlimMessageFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Slim 3 messages.
  *

--- a/src/StreamFactory/DiactorosStreamFactory.php
+++ b/src/StreamFactory/DiactorosStreamFactory.php
@@ -7,6 +7,10 @@ use Laminas\Diactoros\Stream as LaminasStream;
 use Psr\Http\Message\StreamInterface;
 use Zend\Diactoros\Stream as ZendStream;
 
+if (!interface_exists(StreamFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\DiactorosStreamFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Diactoros streams.
  *

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -5,6 +5,10 @@ namespace Http\Message\StreamFactory;
 use GuzzleHttp\Psr7\Utils;
 use Http\Message\StreamFactory;
 
+if (!interface_exists(StreamFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\GuzzleStreamFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Guzzle streams.
  *

--- a/src/StreamFactory/SlimStreamFactory.php
+++ b/src/StreamFactory/SlimStreamFactory.php
@@ -6,6 +6,10 @@ use Http\Message\StreamFactory;
 use Psr\Http\Message\StreamInterface;
 use Slim\Http\Stream;
 
+if (!interface_exists(StreamFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\SlimStreamFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Slim 3 streams.
  *

--- a/src/UriFactory/DiactorosUriFactory.php
+++ b/src/UriFactory/DiactorosUriFactory.php
@@ -7,6 +7,10 @@ use Laminas\Diactoros\Uri as LaminasUri;
 use Psr\Http\Message\UriInterface;
 use Zend\Diactoros\Uri as ZendUri;
 
+if (!interface_exists(UriFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\DiactorosUriFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Diactoros URI.
  *

--- a/src/UriFactory/GuzzleUriFactory.php
+++ b/src/UriFactory/GuzzleUriFactory.php
@@ -7,6 +7,10 @@ use Http\Message\UriFactory;
 
 use function GuzzleHttp\Psr7\uri_for;
 
+if (!interface_exists(UriFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\GuzzleUriFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Guzzle URI.
  *

--- a/src/UriFactory/SlimUriFactory.php
+++ b/src/UriFactory/SlimUriFactory.php
@@ -6,6 +6,10 @@ use Http\Message\UriFactory;
 use Psr\Http\Message\UriInterface;
 use Slim\Http\Uri;
 
+if (!interface_exists(UriFactory::class)) {
+    throw new \LogicException('You cannot use "Http\Message\MessageFactory\SlimUriFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead');
+}
+
 /**
  * Creates Slim 3 URI.
  *


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT

`php-http/message-factory` contains only deprecated interfaces. It'd be great to not force users of this lib to install it. Note that all concerned classes are already deprecated since years.