### PR TITLE
fix code to actually be compatible with psr/http-message 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout code
@@ -31,12 +31,37 @@ jobs:
       - name: Execute tests
         run: composer test
 
+  psr-7_2:
+    name: PHP PSR-7 2.0
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          rm src/MessageFactory/SlimMessageFactory.php src/StreamFactory/SlimStreamFactory.php src/UriFactory/SlimUriFactory.php spec/MessageFactory/SlimMessageFactorySpec.php spec/StreamFactory/SlimStreamFactorySpec.php spec/UriFactory/SlimUriFactorySpec.php
+          composer remove --dev "slim/slim" --no-interaction --no-update
+          composer require "psr/http-message:^2.0" --no-interaction --no-update
+          composer update --prefer-dist --prefer-stable --no-interaction --no-progress
+
+      - name: Execute tests
+        run: composer test
+
   lowest:
     name: PHP ${{ matrix.php }} Lowest
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4']
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.14.0] - 2023-04-14
+## [1.15.0] - 2023-05-10
+
+- Actually make compatible with PSR-7 1.1 and 2.0
+- Drop support for PHP 7.1
+
+## [1.14.0] - 2023-04-14 (broken)
+
+**This release is not actually compatible with PSR-7 1.1 or 2.0**
 
 - Allow installation with http-message (PSR-7) version 2 in addition to version 1.
 - Support for PHP 8.2

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "clue/stream-filter": "^1.5",
         "php-http/message-factory": "^1.0.2",
-        "psr/http-message": "^1.0 || ^2.0"
+        "psr/http-message": "^1.1 || ^2.0"
     },
     "provide": {
         "php-http/message-factory-implementation": "1.0"
@@ -26,10 +26,10 @@
     "require-dev": {
         "ext-zlib": "*",
         "ergebnis/composer-normalize": "^2.6",
-        "guzzlehttp/psr7": "^1.0",
+        "guzzlehttp/psr7": "^1.0 || ^2.0",
         "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
         "slim/slim": "^3.0",
-        "laminas/laminas-diactoros": "^2.0"
+        "laminas/laminas-diactoros": "^2.0 || ^3.0"
     },
     "suggest": {
         "ext-zlib": "Used with compressor/decompressor streams",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,26 +116,6 @@ parameters:
 			path: src/CookieUtil.php
 
 		-
-			message: "#^Method Http\\\\Message\\\\Encoding\\\\ChunkStream\\:\\:fill\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Encoding/ChunkStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Encoding\\\\FilteredStream\\:\\:fill\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Encoding/FilteredStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Encoding\\\\FilteredStream\\:\\:rewind\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Encoding/FilteredStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Encoding\\\\FilteredStream\\:\\:seek\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Encoding/FilteredStream.php
-
-		-
 			message: "#^Method Http\\\\Message\\\\MessageFactory\\\\DiactorosMessageFactory\\:\\:createRequest\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/MessageFactory/DiactorosMessageFactory.php
@@ -181,23 +161,8 @@ parameters:
 			path: src/RequestMatcher/RequestMatcher.php
 
 		-
-			message: "#^Property Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:\\$size \\(int\\) does not accept int\\|null\\.$#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
 			message: "#^Property Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:\\$resource \\(resource\\) does not accept resource\\|false\\.$#"
 			count: 2
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Dead catch \\- Exception is already caught#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:detach\\(\\) should return resource\\|null but empty return statement found\\.$#"
-			count: 1
 			path: src/Stream/BufferedStream.php
 
 		-
@@ -207,36 +172,6 @@ parameters:
 
 		-
 			message: "#^Property Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:\\$resource \\(resource\\) does not accept null\\.$#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:getSize\\(\\) should return int\\|null but empty return statement found\\.$#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:tell\\(\\) should return int but returns int\\|false\\.$#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:seek\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:rewind\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/Stream/BufferedStream.php
-
-		-
-			message: "#^Method Http\\\\Message\\\\Stream\\\\BufferedStream\\:\\:read\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: src/Stream/BufferedStream.php
 

--- a/spec/Decorator/MessageDecoratorSpec.php
+++ b/spec/Decorator/MessageDecoratorSpec.php
@@ -69,9 +69,9 @@ class MessageDecoratorSpec extends ObjectBehavior
 
     public function it_has_a_header(MessageInterface $message)
     {
-        $message->getHeader('Content-Type')->willReturn('application/xml');
+        $message->getHeader('Content-Type')->willReturn(['application/xml']);
 
-        $this->getHeader('Content-Type')->shouldReturn('application/xml');
+        $this->getHeader('Content-Type')->shouldReturn(['application/xml']);
     }
 
     public function it_has_a_header_line(MessageInterface $message)

--- a/spec/Decorator/StreamDecoratorSpec.php
+++ b/spec/Decorator/StreamDecoratorSpec.php
@@ -95,7 +95,7 @@ class StreamDecoratorSpec extends ObjectBehavior
 
     public function it_writes_to_the_stream(StreamInterface $stream)
     {
-        $stream->write('body')->shouldBeCalled();
+        $stream->write('body')->shouldBeCalled()->willReturn(4);
 
         $this->write('body');
     }

--- a/spec/Encoding/FilteredStreamStubSpec.php
+++ b/spec/Encoding/FilteredStreamStubSpec.php
@@ -57,12 +57,12 @@ class FilteredStreamStubSpec extends ObjectBehavior
 
 class FilteredStreamStub extends FilteredStream
 {
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'convert.base64-encode';
     }
 
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'convert.base64-encode';
     }

--- a/spec/Encoding/MemoryStream.php
+++ b/spec/Encoding/MemoryStream.php
@@ -28,12 +28,12 @@ class MemoryStream implements StreamInterface
         $this->chunkSize = $chunkSize;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContents();
     }
 
-    public function close()
+    public function close(): void
     {
         fclose($this->resource);
     }
@@ -46,64 +46,64 @@ class MemoryStream implements StreamInterface
         return $resource;
     }
 
-    public function getSize()
+    public function getSize(): int
     {
         return $this->size;
     }
 
-    public function tell()
+    public function tell(): int
     {
         return ftell($this->resource);
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return feof($this->resource);
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return true;
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         fseek($this->resource, $offset, $whence);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return true;
     }
 
-    public function write($string)
+    public function write(string $string): int
     {
-        fwrite($this->resource, $string);
+        return fwrite($this->resource, $string);
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function read($length)
+    public function read(int $length): string
     {
         return fread($this->resource, min($this->chunkSize, $length));
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $this->rewind();
 
         return $this->read($this->size);
     }
 
-    public function getMetadata($key = null)
+    public function getMetadata(string $key = null)
     {
         $metadata = stream_get_meta_data($this->resource);
 

--- a/spec/Formatter/CurlCommandFormatterSpec.php
+++ b/spec/Formatter/CurlCommandFormatterSpec.php
@@ -25,7 +25,8 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $request->getUri()->willReturn($uri);
         $request->getBody()->willReturn($body);
 
-        $uri->withFragment('')->shouldBeCalled()->willReturn('http://foo.com/bar');
+        $uri->withFragment('')->shouldBeCalled()->willReturn($uri);
+        $uri->__toString()->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('GET');
         $request->getProtocolVersion()->willReturn('1.1');
 
@@ -43,9 +44,10 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $body->__toString()->willReturn('body " data'." test' bar");
         $body->getSize()->willReturn(1);
         $body->isSeekable()->willReturn(true);
-        $body->rewind()->willReturn(true);
+        $body->rewind()->shouldBeCalled();
 
-        $uri->withFragment('')->shouldBeCalled()->willReturn('http://foo.com/bar');
+        $uri->withFragment('')->shouldBeCalled()->willReturn($uri);
+        $uri->__toString()->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('POST');
         $request->getProtocolVersion()->willReturn('2.0');
 
@@ -65,10 +67,10 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $request->getUri()->willReturn($uri);
         $request->getBody()->willReturn($body);
 
-        $uri->withFragment('')->shouldBeCalled()->willReturn('http://foo.com/bar');
+        $uri->withFragment('')->shouldBeCalled()->willReturn($uri);
+        $uri->__toString()->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('GET');
         $request->getProtocolVersion()->willReturn('1.1');
-        $uri->withFragment('')->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getHeaders()->willReturn(['user-agent' => ['foobar-browser']]);
 
         $this->formatRequest($request)->shouldReturn("curl 'http://foo.com/bar' -A 'foobar-browser'");
@@ -82,9 +84,10 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $body->__toString()->willReturn("\0");
         $body->getSize()->willReturn(1);
         $body->isSeekable()->willReturn(true);
-        $body->rewind()->willReturn(true);
+        $body->rewind()->shouldBeCalled();
 
-        $uri->withFragment('')->willReturn('http://foo.com/bar');
+        $uri->withFragment('')->shouldBeCalled()->willReturn($uri);
+        $uri->__toString()->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('POST');
         $request->getProtocolVersion()->willReturn('1.1');
         $request->getHeaders()->willReturn([]);
@@ -100,9 +103,10 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $body->__toString()->willReturn("foo\nbar");
         $body->getSize()->willReturn(1);
         $body->isSeekable()->willReturn(true);
-        $body->rewind()->willReturn(true);
+        $body->rewind()->shouldBeCalled();
 
-        $uri->withFragment('')->willReturn('http://foo.com/bar');
+        $uri->withFragment('')->shouldBeCalled()->willReturn($uri);
+        $uri->__toString()->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('POST');
         $request->getProtocolVersion()->willReturn('1.1');
         $request->getHeaders()->willReturn([]);
@@ -120,7 +124,8 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $body->__toString()->shouldNotBeCalled();
         $body->rewind()->shouldNotBeCalled();
 
-        $uri->withFragment('')->willReturn('http://foo.com/bar');
+        $uri->withFragment('')->shouldBeCalled()->willReturn($uri);
+        $uri->__toString()->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('POST');
         $request->getProtocolVersion()->willReturn('1.1');
         $request->getHeaders()->willReturn([]);
@@ -133,12 +138,13 @@ class CurlCommandFormatterSpec extends ObjectBehavior
         $request->getUri()->willReturn($uri);
         $request->getBody()->willReturn($body);
 
-        $body->__toString()->willReturn('a very long body');
+        $body->__toString()->shouldNotBeCalled();
         $body->getSize()->willReturn(2097153);
         $body->isSeekable()->willReturn(true);
-        $body->rewind()->willReturn(true);
+        $body->rewind()->shouldNotBeCalled();
 
-        $uri->withFragment('')->willReturn('http://foo.com/bar');
+        $uri->withFragment('')->shouldBeCalled()->willReturn($uri);
+        $uri->__toString()->shouldBeCalled()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('POST');
         $request->getProtocolVersion()->willReturn('1.1');
         $request->getHeaders()->willReturn([]);

--- a/src/Decorator/MessageDecorator.php
+++ b/src/Decorator/MessageDecorator.php
@@ -20,26 +20,18 @@ trait MessageDecorator
      *
      * Since the underlying Message is immutable as well
      * exposing it is not an issue, because it's state cannot be altered
-     *
-     * @return MessageInterface
      */
-    public function getMessage()
+    public function getMessage(): MessageInterface
     {
         return $this->message;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->message->getProtocolVersion();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
         $new = clone $this;
         $new->message = $this->message->withProtocolVersion($version);
@@ -47,42 +39,27 @@ trait MessageDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->message->getHeaders();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasHeader($header)
+    public function hasHeader(string $header): bool
     {
         return $this->message->hasHeader($header);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeader($header)
+    public function getHeader(string $header): array
     {
         return $this->message->getHeader($header);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeaderLine($header)
+    public function getHeaderLine(string $header): string
     {
         return $this->message->getHeaderLine($header);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withHeader($header, $value)
+    public function withHeader(string $header, $value): MessageInterface
     {
         $new = clone $this;
         $new->message = $this->message->withHeader($header, $value);
@@ -90,10 +67,7 @@ trait MessageDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader(string $header, $value): MessageInterface
     {
         $new = clone $this;
         $new->message = $this->message->withAddedHeader($header, $value);
@@ -101,10 +75,7 @@ trait MessageDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withoutHeader($header)
+    public function withoutHeader(string $header): MessageInterface
     {
         $new = clone $this;
         $new->message = $this->message->withoutHeader($header);
@@ -112,18 +83,12 @@ trait MessageDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         return $this->message->getBody();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         $new = clone $this;
         $new->message = $this->message->withBody($body);

--- a/src/Decorator/RequestDecorator.php
+++ b/src/Decorator/RequestDecorator.php
@@ -16,10 +16,8 @@ trait RequestDecorator
 
     /**
      * Exchanges the underlying request with another.
-     *
-     * @return self
      */
-    public function withRequest(RequestInterface $request)
+    public function withRequest(RequestInterface $request): RequestInterface
     {
         $new = clone $this;
         $new->message = $request;
@@ -27,18 +25,12 @@ trait RequestDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRequestTarget()
+    public function getRequestTarget(): string
     {
         return $this->message->getRequestTarget();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget(string $requestTarget): RequestInterface
     {
         $new = clone $this;
         $new->message = $this->message->withRequestTarget($requestTarget);
@@ -46,18 +38,12 @@ trait RequestDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->message->getMethod();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withMethod($method)
+    public function withMethod(string $method): RequestInterface
     {
         $new = clone $this;
         $new->message = $this->message->withMethod($method);
@@ -65,18 +51,12 @@ trait RequestDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return $this->message->getUri();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, bool $preserveHost = false): RequestInterface
     {
         $new = clone $this;
         $new->message = $this->message->withUri($uri, $preserveHost);

--- a/src/Decorator/ResponseDecorator.php
+++ b/src/Decorator/ResponseDecorator.php
@@ -15,10 +15,8 @@ trait ResponseDecorator
 
     /**
      * Exchanges the underlying response with another.
-     *
-     * @return self
      */
-    public function withResponse(ResponseInterface $response)
+    public function withResponse(ResponseInterface $response): ResponseInterface
     {
         $new = clone $this;
         $new->message = $response;
@@ -26,18 +24,12 @@ trait ResponseDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->message->getStatusCode();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
     {
         $new = clone $this;
         $new->message = $this->message->withStatus($code, $reasonPhrase);
@@ -45,10 +37,7 @@ trait ResponseDecorator
         return $new;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->message->getReasonPhrase();
     }

--- a/src/Decorator/StreamDecorator.php
+++ b/src/Decorator/StreamDecorator.php
@@ -16,122 +16,77 @@ trait StreamDecorator
      */
     protected $stream;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->stream->__toString();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function close()
+    public function close(): void
     {
         $this->stream->close();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function detach()
     {
         return $this->stream->detach();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->stream->getSize();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function tell()
+    public function tell(): int
     {
         return $this->stream->tell();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function eof()
+    public function eof(): bool
     {
         return $this->stream->eof();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return $this->stream->isSeekable();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         $this->stream->seek($offset, $whence);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function rewind()
+    public function rewind(): void
     {
         $this->stream->rewind();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->stream->isWritable();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function write($string)
+    public function write(string $string): int
     {
         return $this->stream->write($string);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->stream->isReadable();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function read($length)
+    public function read(int $length): string
     {
         return $this->stream->read($length);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getContents()
+    public function getContents(): string
     {
         return $this->stream->getContents();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getMetadata($key = null)
+    public function getMetadata(string $key = null)
     {
         return $this->stream->getMetadata($key);
     }

--- a/src/Encoding/ChunkStream.php
+++ b/src/Encoding/ChunkStream.php
@@ -9,26 +9,17 @@ namespace Http\Message\Encoding;
  */
 class ChunkStream extends FilteredStream
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'chunk';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'dechunk';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function fill()
+    protected function fill(): void
     {
         parent::fill();
 

--- a/src/Encoding/CompressStream.php
+++ b/src/Encoding/CompressStream.php
@@ -27,18 +27,12 @@ class CompressStream extends FilteredStream
         $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => 15]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'zlib.deflate';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'zlib.inflate';
     }

--- a/src/Encoding/DechunkStream.php
+++ b/src/Encoding/DechunkStream.php
@@ -11,18 +11,12 @@ namespace Http\Message\Encoding;
  */
 class DechunkStream extends FilteredStream
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'dechunk';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'chunk';
     }

--- a/src/Encoding/DecompressStream.php
+++ b/src/Encoding/DecompressStream.php
@@ -27,18 +27,12 @@ class DecompressStream extends FilteredStream
         $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => 15, 'level' => $level]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'zlib.inflate';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'zlib.deflate';
     }

--- a/src/Encoding/DeflateStream.php
+++ b/src/Encoding/DeflateStream.php
@@ -26,7 +26,7 @@ class DeflateStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'zlib.deflate';
     }
@@ -34,7 +34,7 @@ class DeflateStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'zlib.inflate';
     }

--- a/src/Encoding/Filter/Chunk.php
+++ b/src/Encoding/Filter/Chunk.php
@@ -9,11 +9,7 @@ namespace Http\Message\Encoding\Filter;
  */
 class Chunk extends \php_user_filter
 {
-    /**
-     * {@inheritdoc}
-     */
-    #[\ReturnTypeWillChange]
-    public function filter($in, $out, &$consumed, $closing)
+    public function filter($in, $out, &$consumed, $closing): int
     {
         while ($bucket = stream_bucket_make_writeable($in)) {
             $lenbucket = stream_bucket_new($this->stream, dechex($bucket->datalen)."\r\n");

--- a/src/Encoding/FilteredStream.php
+++ b/src/Encoding/FilteredStream.php
@@ -75,10 +75,7 @@ abstract class FilteredStream implements StreamInterface
         $this->stream = $stream;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function read($length)
+    public function read(int $length): string
     {
         if (strlen($this->buffer) >= $length) {
             $read = substr($this->buffer, 0, $length);
@@ -101,10 +98,7 @@ abstract class FilteredStream implements StreamInterface
         return $read.$this->read($length - strlen($read));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function eof()
+    public function eof(): bool
     {
         return $this->stream->eof() && '' === $this->buffer;
     }
@@ -116,7 +110,7 @@ abstract class FilteredStream implements StreamInterface
      * This allow to get last data in the PHP buffer otherwise this
      * bug is present : https://bugs.php.net/bug.php?id=48725
      */
-    protected function fill()
+    protected function fill(): void
     {
         $readFilterCallback = $this->readFilterCallback;
         $this->buffer .= $readFilterCallback($this->stream->read(self::BUFFER_SIZE));
@@ -129,7 +123,7 @@ abstract class FilteredStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function getContents()
+    public function getContents(): string
     {
         $buffer = '';
 
@@ -149,15 +143,12 @@ abstract class FilteredStream implements StreamInterface
     /**
      * Always returns null because we can't tell the size of a stream when we filter.
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContents();
     }
@@ -167,24 +158,24 @@ abstract class FilteredStream implements StreamInterface
      *
      * We would need to buffer and process everything to allow seeking.
      */
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
     /**
-     * {@inheritdoc}
+     * Filtered streams are not seekable and can thus not be rewound.
      */
-    public function rewind()
+    public function rewind(): void
     {
         @trigger_error('Filtered streams are not seekable. This method will start raising an exception in the next major version', E_USER_DEPRECATED);
         $this->doRewind();
     }
 
     /**
-     * {@inheritdoc}
+     * Filtered streams are not seekable.
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         @trigger_error('Filtered streams are not seekable. This method will start raising an exception in the next major version', E_USER_DEPRECATED);
         $this->doSeek($offset, $whence);
@@ -193,11 +184,9 @@ abstract class FilteredStream implements StreamInterface
     /**
      * Returns the read filter name.
      *
-     * @return string
-     *
      * @deprecated since version 1.5, will be removed in 2.0
      */
-    public function getReadFilter()
+    public function getReadFilter(): string
     {
         @trigger_error('The '.__CLASS__.'::'.__METHOD__.' method is deprecated since version 1.5 and will be removed in 2.0.', E_USER_DEPRECATED);
 
@@ -206,19 +195,15 @@ abstract class FilteredStream implements StreamInterface
 
     /**
      * Returns the write filter name.
-     *
-     * @return string
      */
-    abstract protected function readFilter();
+    abstract protected function readFilter(): string;
 
     /**
      * Returns the write filter name.
      *
-     * @return string
-     *
      * @deprecated since version 1.5, will be removed in 2.0
      */
-    public function getWriteFilter()
+    public function getWriteFilter(): string
     {
         @trigger_error('The '.__CLASS__.'::'.__METHOD__.' method is deprecated since version 1.5 and will be removed in 2.0.', E_USER_DEPRECATED);
 
@@ -227,8 +212,6 @@ abstract class FilteredStream implements StreamInterface
 
     /**
      * Returns the write filter name.
-     *
-     * @return string
      */
-    abstract protected function writeFilter();
+    abstract protected function writeFilter(): string;
 }

--- a/src/Encoding/GzipDecodeStream.php
+++ b/src/Encoding/GzipDecodeStream.php
@@ -30,7 +30,7 @@ class GzipDecodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'zlib.inflate';
     }
@@ -38,7 +38,7 @@ class GzipDecodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'zlib.deflate';
     }

--- a/src/Encoding/GzipEncodeStream.php
+++ b/src/Encoding/GzipEncodeStream.php
@@ -30,7 +30,7 @@ class GzipEncodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'zlib.deflate';
     }
@@ -38,7 +38,7 @@ class GzipEncodeStream extends FilteredStream
     /**
      * {@inheritdoc}
      */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'zlib.inflate';
     }

--- a/src/Encoding/InflateStream.php
+++ b/src/Encoding/InflateStream.php
@@ -27,18 +27,12 @@ class InflateStream extends FilteredStream
         $this->writeFilterCallback = Filter\fun($this->writeFilter(), ['window' => -15, 'level' => $level]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function readFilter()
+    protected function readFilter(): string
     {
         return 'zlib.inflate';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function writeFilter()
+    protected function writeFilter(): string
     {
         return 'zlib.deflate';
     }

--- a/src/StreamFactory/GuzzleStreamFactory.php
+++ b/src/StreamFactory/GuzzleStreamFactory.php
@@ -23,6 +23,7 @@ final class GuzzleStreamFactory implements StreamFactory
             return Utils::streamFor($body);
         }
 
+        // legacy support for guzzle/psr7 1.*
         return \GuzzleHttp\Psr7\stream_for($body);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #153
| Documentation   | -
| License         | MIT


#### What's in this PR?

It seems the CI previously did not install with psr/http-message 2 with the return type declarations.
Fix our code to have the types.

#### TODO

* [x] figure out why the CI still does not install with psr/http-message 2.0
* [x] Build for PSR-7 2.0 without slim
* [x] Adjust the code to be compatible with PSR-7 2.0