### PR TITLE
fix GitHub workflow badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version](https://img.shields.io/github/release/php-http/message.svg?style=flat-square)](https://github.com/php-http/message/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
-[![tests](https://img.shields.io/github/actions/workflow/status/php-http/message/tests.yml?branch=1.x&label=tests)](https://github.com/php-http/message/actions/workflows/ci.yml)
+[![tests](https://img.shields.io/github/actions/workflow/status/php-http/message/tests.yml?branch=1.x&label=tests&style=flat-square)](https://github.com/php-http/message/actions/workflows/tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/php-http/message.svg?style=flat-square)](https://packagist.org/packages/php-http/message)
 
 **HTTP Message related tools.**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version](https://img.shields.io/github/release/php-http/message.svg?style=flat-square)](https://github.com/php-http/message/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
-[![tests](https://github.com/php-http/message/actions/workflows/ci.yml/badge.svg)](https://github.com/php-http/message/actions/workflows/ci.yml)
+[![tests](https://img.shields.io/github/actions/workflow/status/php-http/message/tests.yml?branch=1.x&label=tests)](https://github.com/php-http/message/actions/workflows/ci.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/php-http/message.svg?style=flat-square)](https://packagist.org/packages/php-http/message)
 
 **HTTP Message related tools.**


### PR DESCRIPTION
#### What's in this PR?

fix GitHub workflow badge URL.

See https://github.com/badges/shields/issues/8671

> You need to update your badge URL from
> https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests
> to
> https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main