### PR TITLE
Add mixed return type to `StreamInterface::getMetadata`

### DIFF
--- a/src/Decorator/StreamDecorator.php
+++ b/src/Decorator/StreamDecorator.php
@@ -86,6 +86,9 @@ trait StreamDecorator
         return $this->stream->getContents();
     }
 
+    /**
+     * @return mixed
+     */
     public function getMetadata(string $key = null)
     {
         return $this->stream->getMetadata($key);


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no|
| Related tickets |
| Documentation   | 
| License         | MIT


#### What's in this PR?

Fixes the following error caught by Symfony's PHPUnit Bridge:

```
  1x: Method "Psr\Http\Message\StreamInterface::getMetadata()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Http\Message\Encoding\FilteredStream" now to avoid errors or add an explicit @return annotation to suppress this message.
```



#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)

