### PR TITLE
fix edge case of reading 0 bytes from BufferedStream

### DIFF
--- a/src/Stream/BufferedStream.php
+++ b/src/Stream/BufferedStream.php
@@ -170,6 +170,9 @@ class BufferedStream implements StreamInterface
         if ($length < 0) {
             throw new \InvalidArgumentException('Can not read a negative amount of bytes');
         }
+        if (0 === $length) {
+            return '';
+        }
 
         $read = '';
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

PHPStan discovered that we could try to fread with 0 bytes, which is not allowed.

