### PR TITLE
feat: remove ergebnis/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     },
     "require-dev": {
         "ext-zlib": "*",
-        "ergebnis/composer-normalize": "^2.6",
         "guzzlehttp/psr7": "^1.0 || ^2.0",
         "php-http/message-factory": "^1.0.2",
         "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",


### PR DESCRIPTION
I want to test CI if is needed "ergebnis/composer-normalize" while it runs via docker gh actions